### PR TITLE
Architecture explained

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,7 @@ To run `neurobot` with Matrix homeserver, you can specify credentials in the `.e
 
 ### Debug mode
 
-Add debug flag:
-
-`go run main.go -debug=true`
+Edit `.env` and change `debug` to be `true`
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 It is an engine in which you can define workflows to be triggered by certain events leading to execution of a set of instructions defined under that workflow.
 
+![neurobot's architecture](https://github.com/Automattic/neurobot/blob/master/neurobot-visual.png?raw=true)
+
+> [Explanation of architecture](docs/architecture.md)
+
 Currently supported event triggers:
 
 | Trigger | Variety |
@@ -15,7 +19,21 @@ Currently supported workflow step:
 | Show message on stdout | `stdout` |
 | Post message to a Matrix room | `postMatrixMessage` |
 
-## Instructions to run it
+## How to run neurobot?
+
+### Components
+
+List of concerned files:
+- Compiled program (binary)
+- `.env` - used for configuration
+- `workflows.toml` - used for defining workflows using [TOML syntax](https://toml.io/en/)
+- `wfb.db` - SQLite database file
+
+You can compile the program by `make build` and binary file gets saved in `bin` directory. Then just start the program, by specifying what `.env` file to load. By default it looks for it in the current directory. A sample `.env.sample` file is also provided for use. All configuration sits inside of `.env` file. When starting up, for the first time, a SQLite database would be created and with every run, workflows defined in TOML file are imported, overwriting previous imported data of the defined workflows. TOML file will eventually be replaced by a UI, but that's not on the short-term roadmap. Refer to [TOML file structure](toml-structure.md) to make sense of it.
+
+### Matrix bot
+
+You can skip this section for a quick demo below, but in order to test by posting a message to a Matrix room, you would need to create a bot user (a user that's meant to be programmatically controlled is a bot, there is no other difference between a regular user and bot user) on your Matrix homeserver and supply its access token in the `.env` file. You don't have to name it `neurobot` but for documentation, that's the name we will assume, you have chosen. If your workflows would require matrix actions that require admin priveleges, you can promote `neurobot` to be an admin on the server as well. For a deep understanding, we suggest reading more on [neurobot's Architecture](docs/architecture.md).
 
 ### Quick Demo
 
@@ -42,29 +60,4 @@ Running workflow #1 payload:{Hello }
 
 ### Adding your own workflow
 
-Look inside `workflows.toml` file to figure out how to specify a workflow. Documentation would follow soon.
-
-### Matrix HomeServer
-
-To run `neurobot` with Matrix homeserver, you can specify credentials in the `.env` file and run again by same command:
-
-`go run main.go`
-
-### Debug mode
-
-Edit `.env` and change `debug` to be `true`
-
-## Architecture
-
-![neurobot's architecture](https://github.com/Automattic/neurobot/blob/master/neurobot-visual.png?raw=true)
-
-Engine is built to react on the basis of events. Workflows are defined as an ordered list of workflow steps that are to be executed when the workflow is started. And workflows' execution start when the chosen event for its execution is triggered.
-
-For example: An incoming webhook can trigger a workflow, which can contain workflow step(s) of like posting a message to Matrix room. Or a new item in RSS Feed triggers a workflow, which can execute steps like posting a message to Matrix room and sending an external webhook request.
-
-Right now, there is no UI to define workflows but we are supporting defining workflows in a TOML file for the short-term.
-
-## Learn more
-
-- [Explanation of architecture](docs/architecture.md)
-- [Understand TOML file structure](docs/toml-structure.md)
+Add workflows in your `workflows.toml` file. [Understand TOML file structure](docs/toml-structure.md)

--- a/README.md
+++ b/README.md
@@ -64,4 +64,9 @@ Engine is built to react on the basis of events. Workflows are defined as an ord
 
 For example: An incoming webhook can trigger a workflow, which can contain workflow step(s) of like posting a message to Matrix room. Or a new item in RSS Feed triggers a workflow, which can execute steps like posting a message to Matrix room and sending an external webhook request.
 
-Right now, there is no UI to define triggers, workflows & workflow steps but most likely it will be built as an interaction with the bot user that's meant to be used for this purpose.
+Right now, there is no UI to define workflows but we are supporting defining workflows in a TOML file for the short-term.
+
+## Learn more
+
+- [Explanation of architecture](docs/architecture.md)
+- [Understand TOML file structure](docs/toml-structure.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,50 @@
+Architecture
+============
+
+neurobot's architecture is built to react on the basis of events, not just events within Matrix but outside of Matrix as well. This provides a great foundation to describe any kind of integration that we can possibly think of.
+
+[💥 Trigger] --------> [ 🚀 Workflow = [📡 WorkflowStep] + [📤 WorkflowStep] ]
+
+## Components
+
+The files you need to concern yourself with are:
+- Compiled program (binary)
+- `.env` - used for configuration
+- `workflows.toml` - used for defining workflows using [TOML syntax](https://toml.io/en/)
+- `wfb.db` - SQLite database file
+
+You can compile the program by `make build` and binary file gets saved in `bin` directory. Then just start the program, with the possiblity of specifying what `.env` file to load. By default it looks for it in the current directory. All configuration sits inside of `.env` file. When starting up, for the first time, a SQLite database would be created and with every run, workflows defined in TOML file are imported, overwriting previous imported data of the defined workflows. TOML file will eventually be replaced by a UI, but that's not on the short-term roadmap. Refer to [TOML file structure](toml-structure.md) to make sense of it.
+
+## How does it work?
+
+You need to create a bot user (a user that's meant to be programmatically controlled is a bot, there is no other difference between a regular user and bot user) on your Matrix homeserver and supply its access token in the `.env` file. You don't have to name it `neurobot` but for documentation, that's the name we will assume, you have chosen. If your workflows would require matrix actions that require admin priveleges, you can promote `neurobot` to be an admin on the server.
+
+If you need to post message as a different bot, meaning a different name and picture, you would have to create a new bot user, and supply its credentials (currently only possible to do by directly entering into the `bots` database table). This is an intentional design choice, so that anyone with hosted homeservers can also setup workflows/integrations by just adding more bot users. You would get to choose which bot user to use, in the relevant workflow step. Make sure that bot has been invited to the room, in which its supposed to post a message.
+
+Upon startup, engine would login as all bots individually and maintain a pool of matrix client instances and starts the `sync` process with the homeserver, giving each bot the chance of reacting to events as they come in. It also loads the triggers, workflows and workflow steps that are defined in the database. Do note that TOML file is only parsed once & imported at startup and then everything happens based on the data inside the database. Its only when the program starts again, that TOML file is reimported. In future, we would implement signalling the program to reload TOML file without requiring a reload of the main program itself.
+
+When triggers are loaded, it starts the monitoring process of defined triggers. For `webhook` variety of triggers, we start a single webhooks listener server, which handles all incoming HTTP requests from outside services. All endpoints share a common prefix `webhooks-listener`. For `poller` variety of triggers, it invokes setup mechanism of these triggers, based on which they can keep polling. This isn't well-built yet, just the skeleton of the mechanism exist.
+
+More variety of triggers are planned such as:
+- Matrix based events (commands invoked, emoji reactions etc)
+- Schedule based (Cron)
+
+When workflow steps are loaded, they are just queued up in their specified order within a particular workflow and await start of the workflow. When a workflow starts, it may or may not have a payload to pass to the first workflow step. Every workflow step would accept the payload from the previous workflow step and passes it forward, with any modification it chooses to make to it.
+
+Each trigger and workflow step carries additional meta information based on their variety.
+
+## What other varieties workflow steps are planned?
+
+Hard to put an exhaustive list, as we would build what we need first. Some are:
+
+- Ping an external endpoint with payload data
+- Query API to add more data to payload data
+- DM a certain user
+- Ask questions to a group of users in a DM and aggregate those answers & post in a matrix room. `Stand up meetings`
+- Send email
+
+## What else is planned for the future?
+
+### Keeping tabs on who's online
+
+We have a polyglots command in Automattic, which when invoked can help you find someone who speaks a certain language and is online right now. Supporting such a command would require knowing who is online and this is probably best done by `neurobot` by maintaining a "online users" list, which can simply be utilised by a workflow step.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ When workflow steps are loaded, they are just queued up in their specified order
 
 Each trigger and workflow step carries additional meta information based on their variety.
 
-## What other varieties workflow steps are planned?
+## What other varieties of workflow steps are planned?
 
 Hard to put an exhaustive list, as we would build what we need first. Some are:
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,19 +1,15 @@
 Architecture
 ============
 
-neurobot's architecture is built to react on the basis of events, not just events within Matrix but outside of Matrix as well. This provides a great foundation to describe any kind of integration that we can possibly think of.
+neurobot's architecture is built to react on the basis of events, not just events within Matrix but outside of Matrix as well. This provides a great foundation to describe any kind of integration that we can possibly think of. Workflows are defined as an ordered list of workflow steps that are to be executed when the workflow is started. And workflows' execution start when the chosen event for its execution is triggered.
 
 [💥 Trigger] --------> [ 🚀 Workflow = [📡 WorkflowStep] + [📤 WorkflowStep] ]
 
-## Components
+For example: An incoming webhook can trigger a workflow, which can contain workflow step(s) of like posting a message to Matrix room. Or a new item in RSS Feed triggers a workflow, which can execute steps like posting a message to Matrix room and sending an external webhook request.
 
-The files you need to concern yourself with are:
-- Compiled program (binary)
-- `.env` - used for configuration
-- `workflows.toml` - used for defining workflows using [TOML syntax](https://toml.io/en/)
-- `wfb.db` - SQLite database file
+![neurobot's architecture](https://github.com/Automattic/neurobot/blob/master/neurobot-visual.png?raw=true)
 
-You can compile the program by `make build` and binary file gets saved in `bin` directory. Then just start the program, with the possiblity of specifying what `.env` file to load. By default it looks for it in the current directory. All configuration sits inside of `.env` file. When starting up, for the first time, a SQLite database would be created and with every run, workflows defined in TOML file are imported, overwriting previous imported data of the defined workflows. TOML file will eventually be replaced by a UI, but that's not on the short-term roadmap. Refer to [TOML file structure](toml-structure.md) to make sense of it.
+Right now, there is no UI to define workflows but we are supporting [defining workflows in a TOML file](toml-structure.md) for the short-term.
 
 ## How does it work?
 

--- a/docs/toml-structure.md
+++ b/docs/toml-structure.md
@@ -1,9 +1,47 @@
 TOML Structure
 ==============
 
-We utilise [TOML config file](https://toml.io/en/) to define workflows.
+We utilise [TOML config file](https://toml.io/en/) to define workflows. Highly recommended to get yourself familiar with it.
 
 To define a workflow, you need to define 3 parts:
 - Workflow details
 - Trigger
 - Workflow steps
+
+Workflows are defined in an array `[[workflow]]` with some basic details and a special `identifier` field. Next `[workflow.trigger]` are defined with some basic details and meta fields, which varies with each variety of the trigger. Last comes `[[workflow.step]]` which is itself an array within a single workflow, again defined with some basic details and meta fields, which varies with each variety of the workflow step.
+
+Refer to `workflows-sample.toml` to see a few examples.
+
+## `identifier` field
+
+This special field is what helps in identifing a particular workflow. If this stays same, and all fields are updated, the engine would figure out what workflow to update in the database on subsequent runs. So, this field should never be modified. Internally, its saved as a workflow meta field.
+
+## Disable a workflow
+
+Simply change the value of `active` to `false`
+
+## Meta fields
+
+### Triggers
+
+#### `webhook` trigger
+
+##### `urlSuffix`
+
+This would be the url suffix in webhooks listening endpoint for your trigger. `https://example.com/webhooks-listener/{urlSuffix}`
+
+### Workflow Steps
+
+#### `postMatrixMessage` workflow step
+
+##### `messagePrefix`
+
+This would be added as a prefix to every message that is to be posted.
+
+##### `matrixRoom`
+
+Default matrix room to post the message to, when not specified in payload.
+
+##### `asBot`
+
+What bot user to use to post the message as. `neurobot` bot user is used when not specified.

--- a/docs/toml-structure.md
+++ b/docs/toml-structure.md
@@ -1,0 +1,9 @@
+TOML Structure
+==============
+
+We utilise [TOML config file](https://toml.io/en/) to define workflows.
+
+To define a workflow, you need to define 3 parts:
+- Workflow details
+- Trigger
+- Workflow steps


### PR DESCRIPTION
Markdown changes adding explanation of architecture, best viewed by browsing the markdown files - starting from [README.md](https://github.com/Automattic/neurobot/blob/architecture_explained/README.md (file in this PR)) and just click through. The new documents are [architecture.md](https://github.com/Automattic/neurobot/blob/architecture_explained/docs/architecture.md) and [toml-structure.md](https://github.com/Automattic/neurobot/blob/architecture_explained/docs/toml-structure.md).