### PR TITLE
explicitly choose a device ID upon login

### DIFF
--- a/engine/bots.go
+++ b/engine/bots.go
@@ -70,6 +70,7 @@ func (b *Bot) WakeUp(e *engine) (err error) {
 		Type:             "m.login.password",
 		Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: b.Username},
 		Password:         b.Password,
+		DeviceID:         "NEUROBOT",
 		StoreCredentials: true,
 	})
 	if err != nil {

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -370,6 +370,7 @@ func (e *engine) initMatrixClient(c MatrixClient, s mautrix.Syncer) (err error) 
 		Type:             "m.login.password",
 		Identifier:       mautrix.UserIdentifier{Type: mautrix.IdentifierTypeUser, User: e.matrixusername},
 		Password:         e.matrixpassword,
+		DeviceID:         "NEUROBOT",
 		StoreCredentials: true,
 	})
 	if err != nil {


### PR DESCRIPTION
using login and password with every login creates a new session

if we specify a device ID ourselves, instead of server assigning one to us, there can only be one session for that device, effectively invalidating last session that was created by us.

hence doesn't create a new session everytime it logins