### PR TITLE
Distinction between matrix server name and server url that it connects to

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,6 @@ WORKFLOWS_DEF_TOML_FILE=./workflows.toml
 #
 # Matrix
 #
-#MATRIX_HOMESERVER=http://matrix.test:8008
+#MATRIX_SERVER_NAME=http://matrix.test:8008
 #MATRIX_USERNAME=morpheus
 #MATRIX_PASSWORD=redpill

--- a/.env.sample
+++ b/.env.sample
@@ -16,6 +16,6 @@ WORKFLOWS_DEF_TOML_FILE=./workflows.toml
 #
 # Matrix
 #
-#MATRIX_SERVER_NAME=http://matrix.test:8008
+#MATRIX_SERVER_NAME=matrix.test:443
 #MATRIX_USERNAME=morpheus
 #MATRIX_PASSWORD=redpill

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -57,8 +57,7 @@ func (b *Bot) WakeUp(e *engine) (err error) {
 	b.e = e
 
 	b.log(fmt.Sprintf("Matrix: Activating Bot: %s [%s]", b.Name, b.Identifier))
-
-	client, err := mautrix.NewClient(e.matrixhomeserver, "", "")
+	client, err := mautrix.NewClient(e.matrixServerURL, "", "")
 	if err != nil {
 		return
 	}
@@ -95,7 +94,7 @@ func (b *Bot) HandleStateMemberEvent(source mautrix.EventSource, evt *event.Even
 			b.log(fmt.Sprintf("Invitation for %s\n", evt.RoomID))
 
 			// ensure the invitation is for a room within our homeserver only
-			matrixHSHost := strings.Split(strings.Split(b.e.matrixhomeserver, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
+			matrixHSHost := strings.Split(strings.Split(b.e.matrixServerName, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
 			if strings.Split(evt.RoomID.String(), ":")[1] == matrixHSHost {
 				// join the room
 				_, err := b.JoinRoom(evt.RoomID)

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -44,7 +44,8 @@ type engine struct {
 	workflowsDefTOMLFile string
 
 	isMatrix         bool // Do we mean to run a matrix client?
-	matrixhomeserver string
+	matrixServerName string
+	matrixServerURL  string
 	matrixusername   string
 	matrixpassword   string
 
@@ -64,7 +65,8 @@ type RunParams struct {
 	PortWebhookListener  string
 	WorkflowsDefTOMLFile string
 	IsMatrix             bool
-	MatrixHomeServer     string
+	MatrixServerName     string // domain in use, part of identity
+	MatrixServerURL      string // actual URL to connect to, for a particular server
 	MatrixUsername       string
 	MatrixPassword       string
 }
@@ -364,7 +366,7 @@ func (e *engine) runPoller() {
 func (e *engine) initMatrixClient(c MatrixClient, s mautrix.Syncer) (err error) {
 	e.client = c
 
-	e.log(fmt.Sprintf("Matrix: Logging into %s as %s", e.matrixhomeserver, e.matrixusername))
+	e.log(fmt.Sprintf("Matrix: Logging into %s as %s", e.matrixServerName, e.matrixusername))
 
 	_, err = e.client.Login(&mautrix.ReqLogin{
 		Type:             "m.login.password",
@@ -389,7 +391,7 @@ func (e *engine) initMatrixClient(c MatrixClient, s mautrix.Syncer) (err error) 
 				e.log(fmt.Sprintf("neurobot got invitation for %s\n", evt.RoomID))
 
 				// ensure the invitation is for a room within our homeserver only
-				matrixHSHost := strings.Split(strings.Split(e.matrixhomeserver, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
+				matrixHSHost := strings.Split(strings.Split(e.matrixServerName, "://")[1], ":")[0] // remove protocol and port info to get just the hostname
 				if strings.Split(evt.RoomID.String(), ":")[1] == matrixHSHost {
 					// join the room
 					_, err := e.client.JoinRoomByID(evt.RoomID)
@@ -459,7 +461,8 @@ func NewEngine(p RunParams) *engine {
 	e.portWebhookListener = p.PortWebhookListener
 	e.workflowsDefTOMLFile = p.WorkflowsDefTOMLFile
 	e.isMatrix = p.IsMatrix
-	e.matrixhomeserver = p.MatrixHomeServer
+	e.matrixServerName = p.MatrixServerName
+	e.matrixServerURL = p.MatrixServerURL
 	e.matrixusername = p.MatrixUsername
 	e.matrixpassword = p.MatrixPassword
 

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -239,7 +239,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 
 		e := NewMockEngine()
 		e.db = dbs
-		e.matrixhomeserver = table.homeserver
+		e.matrixServerURL = table.homeserver
 		e.bots = make(map[uint64]MatrixClient)
 		e.bots[1] = botMatrixClient
 

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	dbFile := os.Getenv("DB_FILE")
-	homeserver := os.Getenv("MATRIX_HOMESERVER")
+	serverName := os.Getenv("MATRIX_SERVER_NAME")
 	username := os.Getenv("MATRIX_USERNAME")
 	password := os.Getenv("MATRIX_PASSWORD")
 	webhookListenerPort := os.Getenv("WEBHOOK_LISTENER_PORT")
@@ -41,8 +41,8 @@ func main() {
 
 	// if either one matrix related env var is specified, make sure all of them are specified
 	isMatrix := false
-	if homeserver != "" || username != "" || password != "" {
-		if homeserver == "" || username == "" || password == "" {
+	if serverName != "" || username != "" || password != "" {
+		if serverName == "" || username == "" || password == "" {
 			log.Fatalf("All matrix related variables need to be supplied if even one of them is supplied")
 		} else {
 			isMatrix = true
@@ -54,13 +54,20 @@ func main() {
 		webhookListenerPort = "8080"
 	}
 
+	// resolve .wellknown to find our server URL to connect
+	wellKnown, err := mautrix.DiscoverClientAPI(serverName)
+	if err != nil {
+		log.Fatal(err)
+	}
+
 	p := engine.RunParams{
 		Debug:                debug,
 		Database:             dbFile,
 		PortWebhookListener:  webhookListenerPort,
 		WorkflowsDefTOMLFile: workflowsDefTOMLFile,
 		IsMatrix:             isMatrix,
-		MatrixHomeServer:     homeserver,
+		MatrixServerName:     serverName,
+		MatrixServerURL:      wellKnown.Homeserver.BaseURL,
 		MatrixUsername:       username,
 		MatrixPassword:       password,
 	}
@@ -68,7 +75,7 @@ func main() {
 	e := engine.NewEngine(p)
 
 	if isMatrix {
-		mc, err := mautrix.NewClient(homeserver, "", "")
+		mc, err := mautrix.NewClient(p.MatrixServerURL, "", "")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/main.go
+++ b/main.go
@@ -49,15 +49,22 @@ func main() {
 		}
 	}
 
-	// set default port for running webhook listener server
-	if webhookListenerPort == "" {
-		webhookListenerPort = "8080"
-	}
-
-	// resolve .wellknown to find our server URL to connect
+	// resolve .well-known to find our server URL to connect
+	var serverURL string
 	wellKnown, err := mautrix.DiscoverClientAPI(serverName)
 	if err != nil {
 		log.Fatal(err)
+	}
+	if wellKnown == nil {
+		// no .well-known setup on host
+		serverURL = serverName
+	} else {
+		serverURL = wellKnown.Homeserver.BaseURL
+	}
+
+	// set default port for running webhook listener server
+	if webhookListenerPort == "" {
+		webhookListenerPort = "8080"
 	}
 
 	p := engine.RunParams{
@@ -67,7 +74,7 @@ func main() {
 		WorkflowsDefTOMLFile: workflowsDefTOMLFile,
 		IsMatrix:             isMatrix,
 		MatrixServerName:     serverName,
-		MatrixServerURL:      wellKnown.Homeserver.BaseURL,
+		MatrixServerURL:      serverURL,
 		MatrixUsername:       username,
 		MatrixPassword:       password,
 	}


### PR DESCRIPTION
Example:

MatrixServerName = [automattic.com](http://automattic.com/)
MatrixServerURI = [automattic.ems.host](http://automattic.ems.host/)

Bots need to check against server name when checking the invite is from within their homeserver only but need a different url to connect to, for all the API interaction that happens.