### PR TITLE
handle localhost matrix server discovery

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"os"
 	"strconv"
+	"strings"
 
 	"neurobot/engine"
 
@@ -51,16 +52,23 @@ func main() {
 
 	// resolve .well-known to find our server URL to connect
 	var serverURL string
+	log.Printf("Discovering Client API for %s\n", serverName)
 	wellKnown, err := mautrix.DiscoverClientAPI(serverName)
 	if err != nil {
-		log.Fatal(err)
-	}
-	if wellKnown == nil {
-		// no .well-known setup on host
-		serverURL = serverName
+		log.Println(err)
+		if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {
+			serverURL = "http://" + serverName
+		} else {
+			serverURL = "https://" + serverName
+		}
 	} else {
-		serverURL = wellKnown.Homeserver.BaseURL
+		if wellKnown != nil {
+			serverURL = wellKnown.Homeserver.BaseURL
+		} else {
+			serverURL = "https://" + serverName
+		}
 	}
+	log.Printf("Server URL for %s: %s", serverName, serverURL)
 
 	// set default port for running webhook listener server
 	if webhookListenerPort == "" {

--- a/main.go
+++ b/main.go
@@ -53,7 +53,7 @@ func main() {
 	// resolve .well-known to find our server URL to connect
 	var serverURL string
 	log.Printf("Discovering Client API for %s\n", serverName)
-	wellKnown, err := mautrix.DiscoverClientAPI(serverName)
+	wellKnown, err := mautrix.DiscoverClientAPI(serverName) // both can be nil for hosts that have https but are not a matrix server
 	if err != nil {
 		log.Println(err)
 		if strings.Contains(err.Error(), "net/http: TLS handshake timeout") {


### PR DESCRIPTION
localhost setup using matrix-env or otherwise will probably not have https, this makes the discovery be considerate of localhost environments where TLS handshake timeout will occur and based on that, use http for server url

previously this was improved in https://github.com/Automattic/neurobot/commit/4c163d8e834180724e134f03072e28d8e05cc135