### PR TITLE
add support of parsing markdown while posting matrix messages

### DIFF
--- a/engine/engine.go
+++ b/engine/engine.go
@@ -34,6 +34,7 @@ type MatrixClient interface {
 	Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error)
 	Sync() error
 	SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error)
+	SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
 	JoinRoomByID(roomID id.RoomID) (resp *mautrix.RespJoinRoom, err error)
 }
 

--- a/engine/mocks_test.go
+++ b/engine/mocks_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/id"
 )
 
@@ -56,6 +57,14 @@ func (m *mockMatrixClient) SendText(roomID id.RoomID, text string) (*mautrix.Res
 	}
 
 	m.msgs = append(m.msgs, text) // store internally for checking, whether this function was called or not
+
+	return &mautrix.RespSendEvent{
+		EventID: "AAAA",
+	}, nil
+}
+
+func (m *mockMatrixClient) SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error) {
+	m.msgs = append(m.msgs, contentJSON.(*event.MessageEventContent).Body) // store internally for checking, whether this function was called or not
 
 	return &mautrix.RespSendEvent{
 		EventID: "AAAA",

--- a/engine/workflow_step_matrix_post_message.go
+++ b/engine/workflow_step_matrix_post_message.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 
 	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/format"
 	"maunium.net/go/mautrix/id"
 )
 
@@ -76,7 +78,9 @@ func (s postMessageMatrixWorkflowStep) run(p payloadData, e *engine) (payloadDat
 	if err != nil {
 		return p, err
 	}
-	_, err = mc.SendText(id.RoomID(room), msg)
+
+	formattedText := format.RenderMarkdown(msg, true, false)
+	_, err = mc.SendMessageEvent(id.RoomID(room), event.EventMessage, &formattedText)
 	if err != nil {
 		return p, err
 	}

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -170,7 +170,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 		{
 			stepPrefixMessage: "Hello: ",
 			payload:           "",
-			messageSent:       "Hello: ",
+			messageSent:       "Hello:",
 			isError:           false,
 			asBot:             "",
 			homeserver:        "https://example.com",
@@ -178,7 +178,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 		{
 			stepPrefixMessage: "Hello: ",
 			payload:           "",
-			messageSent:       "Hello: ",
+			messageSent:       "Hello:",
 			isError:           false,
 			asBot:             "bot_something",
 			homeserver:        "https://example.com",

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,8 @@ require (
 
 require github.com/BurntSushi/toml v1.0.0
 
+require github.com/russross/blackfriday/v2 v2.1.0 // indirect
+
 require (
 	github.com/btcsuite/btcutil v1.0.2 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -423,6 +423,7 @@ github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFR
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/shopspring/decimal v0.0.0-20180709203117-cd690d0c9e24/go.mod h1:M+9NzErvs504Cn4c5DxATwIqPbtswREoFCre64PpcG4=


### PR DESCRIPTION
- evolve MatrixClient interface to include method for sending message events to a room
	- this is one level abstraction below the previous SendText()
- blackfriday library for parsing markdown is paranoid by design so safe to accept user input directly
- fix unit tests as trailing spaces are now removed by markdown parser