### PR TITLE
Bot model and repository

### DIFF
--- a/app/bot/repository.go
+++ b/app/bot/repository.go
@@ -20,3 +20,9 @@ func (repository *Repository) FindActive() (bots []model.Bot, err error) {
 	err = result.All(&bots)
 	return
 }
+
+func (repository *Repository) FindByIdentifier(identifier string) (bot model.Bot, err error) {
+	result := repository.collection.Find(db.Cond{"identifier": identifier})
+	err = result.One(&bot)
+	return
+}

--- a/app/bot/repository.go
+++ b/app/bot/repository.go
@@ -2,6 +2,7 @@ package bot
 
 import (
 	"github.com/upper/db/v4"
+	model "neurobot/model/bot"
 )
 
 type Repository struct {
@@ -12,4 +13,10 @@ func NewRepository(session db.Session) *Repository {
 	return &Repository{
 		collection: session.Collection("bots"),
 	}
+}
+
+func (repository *Repository) FindActive() (bots []model.Bot, err error) {
+	result := repository.collection.Find(db.Cond{"active": 1})
+	err = result.All(&bots)
+	return
 }

--- a/app/bot/repository.go
+++ b/app/bot/repository.go
@@ -1,0 +1,15 @@
+package bot
+
+import (
+	"github.com/upper/db/v4"
+)
+
+type Repository struct {
+	collection db.Collection
+}
+
+func NewRepository(session db.Session) *Repository {
+	return &Repository{
+		collection: session.Collection("bots"),
+	}
+}

--- a/app/bot/repository_test.go
+++ b/app/bot/repository_test.go
@@ -30,3 +30,21 @@ func TestFindActive(t *testing.T) {
 		}
 	})
 }
+
+func TestFindByIdentifier(t *testing.T) {
+	database.Test(func(session db.Session) {
+		bots := fixtures.Bots(session)
+		repository := NewRepository(session)
+
+		bot, err := repository.FindByIdentifier("bar")
+		if err != nil {
+			t.Errorf("failed to find bot by identifier: %s", err)
+		}
+
+		expected := bots["active 2"]
+
+		if !reflect.DeepEqual(bot, expected) {
+			t.Errorf("unexpected result active bots")
+		}
+	})
+}

--- a/app/bot/repository_test.go
+++ b/app/bot/repository_test.go
@@ -1,0 +1,32 @@
+package bot
+
+import (
+	"github.com/upper/db/v4"
+	model "neurobot/model/bot"
+	"neurobot/resources/tests/database"
+	"neurobot/resources/tests/fixtures"
+	"reflect"
+	"testing"
+)
+
+func TestFindActive(t *testing.T) {
+	database.Test(func(session db.Session) {
+		bots := fixtures.Bots(session)
+		repository := NewRepository(session)
+
+		got, err := repository.FindActive()
+		if err != nil {
+			t.Errorf("failed to get active bots: %s", err)
+		}
+
+		if len(got) < 2 {
+			t.Errorf("expected 2 bots, got %d", len(got))
+		}
+
+		expected := []model.Bot{bots["active 1"], bots["active 2"]}
+
+		if !reflect.DeepEqual(got, expected) {
+			t.Errorf("unexpected result active bots")
+		}
+	})
+}

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -3,6 +3,7 @@ package engine
 import (
 	"errors"
 	"fmt"
+	model "neurobot/model/bot"
 	"strings"
 
 	"github.com/upper/db/v4"
@@ -23,6 +24,19 @@ type Bot struct {
 	hydrated bool
 
 	e *engine
+}
+
+func MakeBotFromModelBot(bot model.Bot) Bot {
+	return Bot{
+		ID:          bot.ID,
+		Identifier:  bot.Identifier,
+		Name:        bot.Name,
+		Description: bot.Description,
+		Username:    bot.Username,
+		Password:    bot.Password,
+		CreatedBy:   bot.CreatedBy,
+		Active:      bot.Active,
+	}
 }
 
 func getActiveBots(dbs db.Session) (bots []Bot, err error) {

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -6,7 +6,6 @@ import (
 	model "neurobot/model/bot"
 	"strings"
 
-	"github.com/upper/db/v4"
 	"maunium.net/go/mautrix"
 	"maunium.net/go/mautrix/event"
 )
@@ -37,13 +36,6 @@ func MakeBotFromModelBot(bot model.Bot) Bot {
 		CreatedBy:   bot.CreatedBy,
 		Active:      bot.Active,
 	}
-}
-
-func getBot(dbs db.Session, identifier string) (b Bot, err error) {
-	res := dbs.Collection("bots").Find(db.Cond{"identifier": identifier})
-	err = res.One(&b)
-
-	return
 }
 
 func (b *Bot) IsHydrated() bool {

--- a/engine/bots.go
+++ b/engine/bots.go
@@ -39,16 +39,6 @@ func MakeBotFromModelBot(bot model.Bot) Bot {
 	}
 }
 
-func getActiveBots(dbs db.Session) (bots []Bot, err error) {
-	res := dbs.Collection("bots").Find(db.Cond{"active": 1})
-	err = res.All(&bots)
-	if err != nil {
-		return
-	}
-
-	return
-}
-
 func getBot(dbs db.Session, identifier string) (b Bot, err error) {
 	res := dbs.Collection("bots").Find(db.Cond{"identifier": identifier})
 	err = res.One(&b)

--- a/engine/bots_test.go
+++ b/engine/bots_test.go
@@ -4,33 +4,6 @@ import (
 	"testing"
 )
 
-func TestGetBot(t *testing.T) {
-	dbs, dbs2 := setUp()
-	defer tearDown(dbs, dbs2)
-
-	tables := []struct {
-		identifier string
-		botID      uint64
-	}{
-		{
-			identifier: "bot_afk",
-			botID:      2,
-		},
-		{
-			identifier: "bot_none",
-			botID:      0, // nil value basically, database row doesn't exist
-		},
-	}
-
-	for _, table := range tables {
-		got, _ := getBot(dbs, table.identifier)
-		t.Log(got)
-		if table.botID != got.ID {
-			t.Errorf("didn't get what was expected. identifier: %s got: %d expected: %d", table.identifier, got.ID, table.botID)
-		}
-	}
-}
-
 func TestBotIsHydrated(t *testing.T) {
 	b := &Bot{}
 	if b.IsHydrated() != false {

--- a/engine/bots_test.go
+++ b/engine/bots_test.go
@@ -1,37 +1,8 @@
 package engine
 
 import (
-	"reflect"
 	"testing"
 )
-
-func TestGetActiveBots(t *testing.T) {
-	dbs, dbs2 := setUp()
-	defer tearDown(dbs, dbs2)
-
-	expected := []Bot{
-		{
-			ID:          2,
-			Name:        "AFK Bot",
-			Identifier:  "bot_afk",
-			Description: "Used to post AFK messages for team members",
-			Username:    "bot_afk",
-			Password:    "bot_afk",
-			CreatedBy:   "ashfame",
-			Active:      true,
-		},
-	}
-
-	got, _ := getActiveBots(dbs)
-	if !reflect.DeepEqual(expected, got) {
-		t.Errorf("incorrect bot data")
-	}
-
-	_, err := getActiveBots(dbs2)
-	if err == nil {
-		t.Error("empty database didn't return error")
-	}
-}
 
 func TestGetBot(t *testing.T) {
 	dbs, dbs2 := setUp()

--- a/engine/db_test.go
+++ b/engine/db_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"log"
 	"math/rand"
+	"neurobot/resources/tests/fixtures"
 	"os"
 	"reflect"
 	"strings"
@@ -348,6 +349,9 @@ func setUp() (db.Session, db.Session) {
 		}
 	}
 
+	// Create bot fixtures
+	fixtures.Bots(dbs)
+
 	// Setup empty database now
 	dbs2, err := sqlite.Open(sqlite.ConnectionURL{Database: "./db_empty.db"})
 	if err != nil {
@@ -445,9 +449,5 @@ func getDataInsertsSQL() *[]string {
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (14,13,'messagePrefix','[Alert]');`,
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (15,14,'matrixRoom','');`,
 		`INSERT INTO "workflow_step_meta" ("id","step_id","key","value") VALUES (16,14,'messagePrefix','[Announcement]');`,
-
-		// Bots
-		`INSERT INTO "bots" ("id", "identifier", "name", "description", "username", "password", "created_by", "active") VALUES ('1', 'bot_something', '', '', '', '', 'ashfame', '0');`,
-		`INSERT INTO "bots" ("id", "identifier", "name", "description", "username", "password", "created_by", "active") VALUES ('2', 'bot_afk', 'AFK Bot', 'Used to post AFK messages for team members', 'bot_afk', 'bot_afk', 'ashfame', '1');`,
 	}
 }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -424,9 +424,16 @@ func (e *engine) initMatrixClient(c MatrixClient, s mautrix.Syncer) (err error) 
 
 func (e *engine) wakeUpMatrixBots() (err error) {
 	// load all bots one by one and accept any invitations within our own homeserver
-	bots, err := getActiveBots(e.db)
+	modelBots, err := e.botRepository.FindActive()
 	if err != nil {
 		return
+	}
+
+	// Convert model/bot to engine/bot
+	// TODO: Remove once engine/bot has been replaced in favour of model/bot
+	var bots []Bot
+	for _, modelBot := range modelBots {
+		bots = append(bots, MakeBotFromModelBot(modelBot))
 	}
 
 	// use waitgroup to wait for all bots' instances to be ready

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -9,6 +9,7 @@ import (
 	"neurobot/infrastructure/database"
 	"neurobot/infrastructure/event"
 	"neurobot/infrastructure/http"
+	"neurobot/model/bot"
 	"strings"
 	"sync"
 
@@ -45,8 +46,9 @@ type engine struct {
 	matrixusername   string
 	matrixpassword   string
 
-	db       db.Session
-	eventBus event.Bus
+	db            db.Session
+	eventBus      event.Bus
+	botRepository bot.Repository
 
 	workflows map[uint64]*workflow
 	triggers  map[string]map[string]Trigger
@@ -58,6 +60,7 @@ type engine struct {
 
 type RunParams struct {
 	EventBus             event.Bus
+	BotRepository        bot.Repository
 	Debug                bool
 	Database             string
 	PortWebhookListener  string
@@ -469,6 +472,7 @@ func NewEngine(p RunParams) *engine {
 	e.matrixusername = p.MatrixUsername
 	e.matrixpassword = p.MatrixPassword
 	e.eventBus = p.EventBus
+	e.botRepository = p.BotRepository
 
 	return &e
 }

--- a/engine/workflow_step_matrix_post_message.go
+++ b/engine/workflow_step_matrix_post_message.go
@@ -32,11 +32,14 @@ var getMatrixClient = func(homeserver string) (MatrixClient, error) {
 
 func (s postMessageMatrixWorkflowStep) getMatrixClient(e *engine) (mc MatrixClient, err error) {
 	if s.asBot != "" {
-
-		b, err := getBot(e.db, s.asBot)
+		modelBot, err := e.botRepository.FindByIdentifier(s.asBot)
 		if err != nil {
 			return nil, err
 		}
+
+		// Convert model/bot to engine/bot
+		// TODO: Remove once engine/bot has been replaced in favour of model/bot
+		b := MakeBotFromModelBot(modelBot)
 
 		if !b.IsHydrated() {
 			b.Hydrate(e)

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -65,12 +65,12 @@ func TestGetMatrixClient(t *testing.T) {
 		},
 		// When bot identifier is specified, use the matrix client instatiated by the particular bot credentials
 		{
-			asBot:        "bot_something",
+			asBot:        "foo",
 			clientOrigin: "bot1",
 		},
 		// When bot identifier is specified, use the matrix client instatiated by the particular bot credentials
 		{
-			asBot:        "bot_afk",
+			asBot:        "bar",
 			clientOrigin: "bot2",
 		},
 	}
@@ -148,7 +148,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "Message!",
 			messageSent:       "Test!\nMessage!",
 			isError:           false,
-			asBot:             "bot_something",
+			asBot:             "foo",
 			homeserver:        "https://example.com",
 		},
 		{
@@ -164,7 +164,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "Message!",
 			messageSent:       "Message!",
 			isError:           false,
-			asBot:             "bot_something",
+			asBot:             "foo",
 			homeserver:        "https://example.com",
 		},
 		{
@@ -180,7 +180,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "",
 			messageSent:       "Hello:",
 			isError:           false,
-			asBot:             "bot_something",
+			asBot:             "foo",
 			homeserver:        "https://example.com",
 		},
 		{
@@ -196,7 +196,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "",
 			messageSent:       "",
 			isError:           true,
-			asBot:             "bot_something",
+			asBot:             "foo",
 			homeserver:        "https://example.com",
 		},
 		{
@@ -212,7 +212,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "throwerr",
 			messageSent:       "",
 			isError:           true,
-			asBot:             "bot_something",
+			asBot:             "foo",
 			homeserver:        "https://example.com",
 		},
 		{
@@ -220,7 +220,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 			payload:           "Message!",
 			messageSent:       "Test!\nMessage!",
 			isError:           true,
-			asBot:             "bot_something",        // otherwise e.client will be used
+			asBot:             "foo",                  // otherwise e.client will be used
 			homeserver:        " https://example.com", // invalid url to test returning of an error
 		},
 		{

--- a/engine/workflow_step_matrix_post_message_test.go
+++ b/engine/workflow_step_matrix_post_message_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"neurobot/app/bot"
 	"testing"
 
 	"maunium.net/go/mautrix"
@@ -86,6 +87,7 @@ func TestGetMatrixClient(t *testing.T) {
 		e.bots = make(map[uint64]MatrixClient)
 		e.bots[1] = NewMockMatrixClient("bot1")
 		e.bots[2] = NewMockMatrixClient("bot2")
+		e.botRepository = bot.NewRepository(dbs)
 
 		// get step instance
 		s := &postMessageMatrixWorkflowStep{
@@ -242,6 +244,7 @@ func TestPostMessageMatrixWorkflowStep(t *testing.T) {
 		e.matrixServerURL = table.homeserver
 		e.bots = make(map[uint64]MatrixClient)
 		e.bots[1] = botMatrixClient
+		e.botRepository = bot.NewRepository(dbs)
 
 		s := &postMessageMatrixWorkflowStep{
 			workflowStep: workflowStep{

--- a/main.go
+++ b/main.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"neurobot/app"
+	"neurobot/app/bot"
+	"neurobot/infrastructure/database"
 	"neurobot/infrastructure/event"
 	"os"
 	"strconv"
@@ -41,6 +43,13 @@ func main() {
 	log.Println("Debug:", debug)
 	log.Printf("Loaded environment variables from %s\n", *envFile)
 	log.Printf("Using database file %s\n", dbFile)
+
+	databaseSession, err := database.MakeDatabaseSession()
+	if err != nil {
+		log.Fatalf("%s", err)
+	}
+
+	botRepository := bot.NewRepository(databaseSession)
 
 	bus := event.NewMemoryBus()
 	app.Run(bus)
@@ -84,6 +93,7 @@ func main() {
 
 	p := engine.RunParams{
 		EventBus:             bus,
+		BotRepository:        botRepository,
 		Debug:                debug,
 		PortWebhookListener:  webhookListenerPort,
 		WorkflowsDefTOMLFile: workflowsDefTOMLFile,

--- a/model/bot/bot.go
+++ b/model/bot/bot.go
@@ -1,0 +1,13 @@
+package bot
+
+// Bot is a non-human chat user.
+type Bot struct {
+	ID          uint64 `db:"id,omitempty"`
+	Identifier  string `db:"identifier"`
+	Name        string `db:"name"`
+	Description string `db:"description"`
+	Username    string `db:"username"`
+	Password    string `db:"password"`
+	CreatedBy   string `db:"created_by"`
+	Active      bool   `db:"active"`
+}

--- a/model/bot/repository.go
+++ b/model/bot/repository.go
@@ -1,0 +1,5 @@
+package bot
+
+// Repository facilitates persistence and retrieval of bots.
+type Repository interface {
+}

--- a/model/bot/repository.go
+++ b/model/bot/repository.go
@@ -4,4 +4,7 @@ package bot
 type Repository interface {
 	// FindActive retrieves all active bots.
 	FindActive() ([]Bot, error)
+
+	// FindByIdentifier retrieves a bot by its unique identifier (aka slug).
+	FindByIdentifier(identifier string) (Bot, error)
 }

--- a/model/bot/repository.go
+++ b/model/bot/repository.go
@@ -2,4 +2,6 @@ package bot
 
 // Repository facilitates persistence and retrieval of bots.
 type Repository interface {
+	// FindActive retrieves all active bots.
+	FindActive() ([]Bot, error)
 }

--- a/resources/tests/fixtures/bots.go
+++ b/resources/tests/fixtures/bots.go
@@ -1,0 +1,47 @@
+package fixtures
+
+import (
+	"github.com/upper/db/v4"
+	"neurobot/model/bot"
+)
+
+func Bots(session db.Session) map[string]bot.Bot {
+	fixtures := map[string]bot.Bot{
+		"active 1": {
+			ID:          1,
+			Name:        "foo",
+			Identifier:  "foo",
+			Description: "Foo description",
+			Username:    "foo_username",
+			Password:    "foo_password",
+			CreatedBy:   "foo_creator",
+			Active:      true,
+		},
+		"active 2": {
+			ID:          2,
+			Name:        "bar",
+			Identifier:  "bar",
+			Description: "Bar description",
+			Username:    "bar_username",
+			Password:    "bar_password",
+			CreatedBy:   "bar_creator",
+			Active:      true,
+		},
+		"inactive": {
+			ID:          3,
+			Name:        "baz",
+			Identifier:  "baz",
+			Description: "Baz description",
+			Username:    "baz_username",
+			Password:    "baz_password",
+			CreatedBy:   "baz_creator",
+			Active:      false,
+		},
+	}
+
+	for _, fixture := range fixtures {
+		_, _ = session.Collection("bots").Insert(fixture)
+	}
+
+	return fixtures
+}


### PR DESCRIPTION
This PR extracts the Bot model out of engine. The Bot model in engine is kept for now since it's currently doing some Matrix stuff. Once we extract that, we will be able to remove engine/Bot, but that's out of the scope of this PR.

In this PR we also introduce "fixtures" (for bots) as code instead of as SQL statements. I think using code to express fixtures is more flexible than having them as SQL statements, since the same code can both specify the fixtures, and be used in the tests themselves.
