### PR TITLE
HTTP Server improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ First run, inserts some data into the sqlite database `neurobot.db` which will e
 
 After running the program, you can send a HTTP request using CURL like this:
 
-`curl localhost:8080/webhooks-listener/quickstart?message=Hello`
+`curl localhost:8080/quickstart?message=Hello`
 
 You should see these lines in output:
 
 ```
-Request received on webhook listener! /webhooks-listener/quickstart
+Request received on webhook listener! /quickstart
 suffix: quickstart registered: true
 
 Running workflow #1 payload:{Hello }

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -191,7 +191,7 @@ func (e *engine) registerWebhookTrigger(t *trigger.Trigger) {
 		// Register routes on webhook listener http server
 		err := e.WebhookListener.RegisterRoute(
 			t.Meta["urlSuffix"],
-			func(w netHttp.ResponseWriter, val map[string]string) {
+			func(w netHttp.ResponseWriter, request *netHttp.Request, val map[string]string) {
 				// explicitly set expected payload values here, otherwise it would panic if a nonexistent key on map is accessed later down the pipeline
 				var message string
 				var room string

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -190,7 +190,7 @@ func (e *engine) registerWebhookTrigger(t *trigger.Trigger) {
 	case "webhook":
 		// Register routes on webhook listener http server
 		err := e.WebhookListener.RegisterRoute(
-			fmt.Sprintf("/webhooks-listener/%s", t.Meta["urlSuffix"]),
+			t.Meta["urlSuffix"],
 			func(w netHttp.ResponseWriter, val map[string]string) {
 				// explicitly set expected payload values here, otherwise it would panic if a nonexistent key on map is accessed later down the pipeline
 				var message string

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -36,7 +36,7 @@ type MatrixClient interface {
 
 type engine struct {
 	debug                bool
-	WebhookListener      http.Server
+	WebhookListener      *http.Server
 	workflowsDefTOMLFile string
 
 	isMatrix         bool // Do we mean to run a matrix client?
@@ -62,7 +62,7 @@ type RunParams struct {
 	BotRepository        bot.Repository
 	Debug                bool
 	Database             string
-	WebhookListener      http.Server
+	WebhookListener      *http.Server
 	WorkflowsDefTOMLFile string
 	IsMatrix             bool
 	MatrixServerName     string // domain in use, part of identity

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -32,7 +32,6 @@ func NewServer(port int) *Server {
 
 // Run method starts the http server
 func (s *Server) Run() {
-	log.Printf("Starting webhook listener at port %d", s.port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", s.port), nil); err != nil {
 		log.Fatal(err)
 	}

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -46,7 +46,7 @@ func (s *Server) RegisterRoute(route string, fn requestHandler) error {
 	s.routes[route] = fn
 
 	// handle the actual request
-	http.HandleFunc(route, func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc(fmt.Sprintf("/%s", route), func(w http.ResponseWriter, r *http.Request) {
 		requestParameters, err := s.parseRequest(r)
 		if err != nil {
 			log.Printf("Failed to parse request: %s", err.Error)

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-type registeredRoute func(w http.ResponseWriter, val map[string]string)
+type requestHandler func(w http.ResponseWriter, val map[string]string)
 
 type httpError struct {
 	StatusCode int
@@ -19,14 +19,14 @@ type httpError struct {
 // Server holds the data for running a http server
 type Server struct {
 	port   int
-	routes map[string]registeredRoute
+	routes map[string]requestHandler
 }
 
 // NewServer returns a new instance of http server
 func NewServer(port int) *Server {
 	return &Server{
 		port:   port,
-		routes: make(map[string]registeredRoute),
+		routes: make(map[string]requestHandler),
 	}
 }
 
@@ -39,7 +39,7 @@ func (s *Server) Run() {
 }
 
 // RegisterRoute saves the callback func for a particular route
-func (s *Server) RegisterRoute(route string, fn registeredRoute) error {
+func (s *Server) RegisterRoute(route string, fn requestHandler) error {
 	if _, ok := s.routes[route]; ok {
 		return fmt.Errorf("route %s already registered", route)
 	}

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -49,7 +49,7 @@ func (s *Server) RegisterRoute(route string, fn requestHandler) error {
 	http.HandleFunc(fmt.Sprintf("/%s", route), func(w http.ResponseWriter, r *http.Request) {
 		requestParameters, err := s.parseRequest(r)
 		if err != nil {
-			log.Printf("Failed to parse request: %s", err.Error)
+			log.Printf("Failed to parse request: %s\n", err.Error)
 			http.Error(w, err.Message, err.StatusCode)
 			return
 		}

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 )
 
-type requestHandler func(w http.ResponseWriter, val map[string]string)
+type requestHandler func(w http.ResponseWriter, r *http.Request, val map[string]string)
 
 type httpError struct {
 	StatusCode int
@@ -54,7 +54,7 @@ func (s *Server) RegisterRoute(route string, fn requestHandler) error {
 			return
 		}
 
-		fn(w, requestParameters)
+		fn(w, r, requestParameters)
 	})
 
 	return nil

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -17,15 +17,15 @@ type Server struct {
 }
 
 // NewServer returns a new instance of http server
-func NewServer(port int) Server {
-	return Server{
+func NewServer(port int) *Server {
+	return &Server{
 		port:   port,
 		routes: make(map[string]registeredRoute),
 	}
 }
 
 // Run method starts the http server
-func (s Server) Run() {
+func (s *Server) Run() {
 	log.Printf("Starting webhook listener at port %d", s.port)
 	if err := http.ListenAndServe(fmt.Sprintf(":%d", s.port), nil); err != nil {
 		log.Fatal(err)
@@ -33,7 +33,7 @@ func (s Server) Run() {
 }
 
 // RegisterRoute saves the callback func for a particular route
-func (s Server) RegisterRoute(route string, fn registeredRoute) error {
+func (s *Server) RegisterRoute(route string, fn registeredRoute) error {
 	if _, ok := s.routes[route]; ok {
 		return fmt.Errorf("route %s already registered", route)
 	}

--- a/main.go
+++ b/main.go
@@ -122,6 +122,6 @@ func main() {
 
 	e.Run()
 
-	log.Printf("Starting webhook listener at port %d", webhookListenerPort)
+	log.Printf("Starting webhook listener at port %d\n", webhookListenerPort)
 	webhookListenerServer.Run() // blocking
 }

--- a/main.go
+++ b/main.go
@@ -122,5 +122,6 @@ func main() {
 
 	e.Run()
 
+	log.Printf("Starting webhook listener at port %d", webhookListenerPort)
 	webhookListenerServer.Run() // blocking
 }

--- a/resources/docs/architecture.md
+++ b/resources/docs/architecture.md
@@ -19,7 +19,7 @@ If you need to post message as a different bot, meaning a different name and pic
 
 Upon startup, engine would login as all bots individually and maintain a pool of matrix client instances and starts the `sync` process with the homeserver, giving each bot the chance of reacting to events as they come in. It also loads the triggers, workflows and workflow steps that are defined in the database. Do note that TOML file is only parsed once & imported at startup and then everything happens based on the data inside the database. Its only when the program starts again, that TOML file is reimported. In future, we would implement signalling the program to reload TOML file without requiring a reload of the main program itself.
 
-When triggers are loaded, it starts the monitoring process of defined triggers. For `webhook` variety of triggers, we start a single webhooks listener server, which handles all incoming HTTP requests from outside services. All endpoints share a common prefix `webhooks-listener`. For `poller` variety of triggers, it invokes setup mechanism of these triggers, based on which they can keep polling. This isn't well-built yet, just the skeleton of the mechanism exist.
+When triggers are loaded, it starts the monitoring process of defined triggers. For `webhook` variety of triggers, we start a single webhooks listener server, which handles all incoming HTTP requests from outside services. For `poller` variety of triggers, it invokes setup mechanism of these triggers, based on which they can keep polling. This isn't well-built yet, just the skeleton of the mechanism exist.
 
 More variety of triggers are planned such as:
 - Matrix based events (commands invoked, emoji reactions etc)

--- a/resources/docs/toml-structure.md
+++ b/resources/docs/toml-structure.md
@@ -28,7 +28,7 @@ Simply change the value of `active` to `false`
 
 ##### `urlSuffix`
 
-This would be the url suffix in webhooks listening endpoint for your trigger. `https://example.com/webhooks-listener/{urlSuffix}`
+This would be the url suffix in webhooks listening endpoint for your trigger. `https://example.com/{urlSuffix}`
 
 ### Workflow Steps
 


### PR DESCRIPTION
The webhook listener is already running on a dedicated port, specified through the `WEBHOOK_LISTENER_PORT` env variable, so there is no need to prefix routes with `/webhooks-listener`. A nice consequence of this change is that it will make it easier for request handlers to retrieve the "route", which will now be `/foo` instead of `/webhooks-listener/foo`.

While making this change I also noticed some small refactors that could be done on `Server`, so I applied the [scouts rule](https://www.stepsize.com/blog/how-to-be-an-effective-boy-girl-scout-engineer) :)