### PR TITLE
Implement OnRoomInvite() and JoinRoom() on matrix client

### DIFF
--- a/infrastructure/matrix/client.go
+++ b/infrastructure/matrix/client.go
@@ -9,4 +9,7 @@ type Client interface {
 	Login(username string, password string) error
 	JoinRoom(id room.ID) error
 	SendMessage(roomID room.ID, message message.Message) error
+
+	// OnRoomInvite registers a handler that will be called whenever the currently authenticated user is invited to a room.
+	OnRoomInvite(handler func(roomID room.ID)) error
 }

--- a/infrastructure/matrix/client.go
+++ b/infrastructure/matrix/client.go
@@ -7,5 +7,6 @@ import (
 
 type Client interface {
 	Login(username string, password string) error
+	JoinRoom(id room.ID) error
 	SendMessage(roomID room.ID, message message.Message) error
 }

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -2,7 +2,7 @@ package matrix
 
 import (
 	"maunium.net/go/mautrix"
-	"maunium.net/go/mautrix/event"
+	mautrixEvent "maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
 	mautrixId "maunium.net/go/mautrix/id"
 	msg "neurobot/model/message"
@@ -13,7 +13,7 @@ type mautrixClient interface {
 	Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error)
 	JoinRoom(roomIDorAlias, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
 	SendText(roomID mautrixId.RoomID, text string) (*mautrix.RespSendEvent, error)
-	SendMessageEvent(roomID mautrixId.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
+	SendMessageEvent(roomID mautrixId.RoomID, eventType mautrixEvent.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
 	ResolveAlias(alias mautrixId.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
 }
 
@@ -63,7 +63,7 @@ func (client *client) SendMessage(roomID room.ID, message msg.Message) error {
 	switch message.ContentType() {
 	case msg.Markdown:
 		rendered := format.RenderMarkdown(message.String(), true, false)
-		_, err = client.mautrix.SendMessageEvent(resolvedRoomID, event.EventMessage, rendered)
+		_, err = client.mautrix.SendMessageEvent(resolvedRoomID, mautrixEvent.EventMessage, rendered)
 
 	case msg.PlainText:
 		_, err = client.mautrix.SendText(resolvedRoomID, message.String())

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -18,13 +18,22 @@ type mautrixClient interface {
 }
 
 type client struct {
-	mautrix mautrixClient
+	homeserverURL string
+	mautrix       mautrixClient
 }
 
-func NewMautrixClient(mautrix mautrixClient) *client {
-	return &client{
-		mautrix: mautrix,
+func NewMautrixClient(homeserverURL string) (*client, error) {
+	mautrixClient, err := mautrix.NewClient(homeserverURL, "", "")
+	if err != nil {
+		return nil, err
 	}
+
+	client := client{
+		homeserverURL: homeserverURL,
+		mautrix:       mautrixClient,
+	}
+
+	return &client, nil
 }
 
 func (client *client) Login(username string, password string) error {

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -17,9 +17,15 @@ type mautrixClient interface {
 	ResolveAlias(alias mautrixId.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
 }
 
+type mautrixSyncer interface {
+	mautrix.Syncer
+	mautrix.ExtensibleSyncer
+}
+
 type client struct {
 	homeserverURL string
 	mautrix       mautrixClient
+	syncer        mautrixSyncer
 }
 
 func NewMautrixClient(homeserverURL string) (*client, error) {
@@ -28,9 +34,13 @@ func NewMautrixClient(homeserverURL string) (*client, error) {
 		return nil, err
 	}
 
+	syncer := mautrix.NewDefaultSyncer()
+	mautrixClient.Syncer = syncer
+
 	client := client{
 		homeserverURL: homeserverURL,
 		mautrix:       mautrixClient,
+		syncer:        syncer,
 	}
 
 	return &client, nil

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -11,6 +11,7 @@ import (
 
 type mautrixClient interface {
 	Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error)
+	JoinRoom(roomIDorAlias, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
 	SendText(roomID mautrixId.RoomID, text string) (*mautrix.RespSendEvent, error)
 	SendMessageEvent(roomID mautrixId.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
 	ResolveAlias(alias mautrixId.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
@@ -36,6 +37,12 @@ func (client *client) Login(username string, password string) error {
 	})
 
 	return err
+}
+
+func (client *client) JoinRoom(id room.ID) (err error) {
+	_, err = client.mautrix.JoinRoom(id.ID(), "", "")
+
+	return
 }
 
 func (client *client) SendMessage(roomID room.ID, message msg.Message) error {

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func makeClient() (*client, mocks.MautrixClientMock, mocks.MautrixSyncerMock) {
-	mautrixMock := mocks.NewMockMatrixClient("bot")
+	mautrixMock := mocks.NewMautrixClientMock("bot")
 	syncerMock := mocks.NewMockMatrixSyncer()
 
 	client := client{

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -12,9 +12,10 @@ func makeClient() (*client, mocks.MautrixClientMock, mocks.MautrixSyncerMock) {
 	syncerMock := mocks.NewMockMatrixSyncer()
 
 	client := client{
-		homeserverURL: "matrix.test",
-		mautrix:       mautrixMock,
-		syncer:        syncerMock,
+		homeserverURL:    "matrix.test",
+		mautrix:          mautrixMock,
+		syncer:           syncerMock,
+		listenersEnabled: false,
 	}
 
 	return &client, mautrixMock, syncerMock

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -7,18 +7,21 @@ import (
 	"testing"
 )
 
-func makeClient() (*client, mocks.MautrixClientMock) {
+func makeClient() (*client, mocks.MautrixClientMock, mocks.MautrixSyncerMock) {
 	mautrixMock := mocks.NewMockMatrixClient("bot")
+	syncerMock := mocks.NewMockMatrixSyncer()
+
 	client := client{
 		homeserverURL: "matrix.test",
 		mautrix:       mautrixMock,
+		syncer:        syncerMock,
 	}
 
-	return &client, mautrixMock
+	return &client, mautrixMock, syncerMock
 }
 
 func TestSendPlainTextMessage(t *testing.T) {
-	client, mautrixMock := makeClient()
+	client, mautrixMock, _ := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewPlainTextMessage("foo")
 
@@ -33,7 +36,7 @@ func TestSendPlainTextMessage(t *testing.T) {
 }
 
 func TestSendMarkdownMessage(t *testing.T) {
-	client, mautrixMock := makeClient()
+	client, mautrixMock, _ := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewMarkdownMessage("foo")
 
@@ -48,7 +51,7 @@ func TestSendMarkdownMessage(t *testing.T) {
 }
 
 func TestJoinRoom(t *testing.T) {
-	client, mautrixMock := makeClient()
+	client, mautrixMock, _ := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 
 	err := client.JoinRoom(roomID)

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -7,10 +7,15 @@ import (
 	"testing"
 )
 
-func TestSendPlainTextMessage(t *testing.T) {
-	mockClient := mocks.NewMockMatrixClient("bot")
-	client := NewMautrixClient(mockClient)
+func makeClient() (*client, mocks.MautrixClientMock) {
+	mautrixMock := mocks.NewMockMatrixClient("bot")
+	client := NewMautrixClient(mautrixMock)
 
+	return client, mautrixMock
+}
+
+func TestSendPlainTextMessage(t *testing.T) {
+	client, mockClient := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewPlainTextMessage("foo")
 
@@ -25,9 +30,7 @@ func TestSendPlainTextMessage(t *testing.T) {
 }
 
 func TestSendMarkdownMessage(t *testing.T) {
-	mockClient := mocks.NewMockMatrixClient("bot")
-	client := NewMautrixClient(mockClient)
-
+	client, mockClient := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewMarkdownMessage("foo")
 

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -9,9 +9,12 @@ import (
 
 func makeClient() (*client, mocks.MautrixClientMock) {
 	mautrixMock := mocks.NewMockMatrixClient("bot")
-	client := NewMautrixClient(mautrixMock)
+	client := client{
+		homeserverURL: "matrix.test",
+		mautrix:       mautrixMock,
+	}
 
-	return client, mautrixMock
+	return &client, mautrixMock
 }
 
 func TestSendPlainTextMessage(t *testing.T) {

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -13,6 +13,7 @@ func makeClient() (*client, mocks.MautrixClientMock, mocks.MautrixSyncerMock) {
 
 	client := client{
 		homeserverURL:    "matrix.test",
+		homeserverDomain: "matrix.test",
 		mautrix:          mautrixMock,
 		syncer:           syncerMock,
 		listenersEnabled: false,

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -15,7 +15,7 @@ func makeClient() (*client, mocks.MautrixClientMock) {
 }
 
 func TestSendPlainTextMessage(t *testing.T) {
-	client, mockClient := makeClient()
+	client, mautrixMock := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewPlainTextMessage("foo")
 
@@ -24,13 +24,13 @@ func TestSendPlainTextMessage(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !mockClient.WasMessageSent("foo") {
+	if !mautrixMock.WasMessageSent("foo") {
 		t.Error("message: foo wasn't sent")
 	}
 }
 
 func TestSendMarkdownMessage(t *testing.T) {
-	client, mockClient := makeClient()
+	client, mautrixMock := makeClient()
 	roomID, _ := room.NewID("!foo:matrix.test")
 	message := msg.NewMarkdownMessage("foo")
 
@@ -39,7 +39,7 @@ func TestSendMarkdownMessage(t *testing.T) {
 		t.Error(err)
 	}
 
-	if !mockClient.WasMessageSent("foo") {
+	if !mautrixMock.WasMessageSent("foo") {
 		t.Errorf("message: %s wasn't sent", message.String())
 	}
 }

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -43,3 +43,17 @@ func TestSendMarkdownMessage(t *testing.T) {
 		t.Errorf("message: %s wasn't sent", message.String())
 	}
 }
+
+func TestJoinRoom(t *testing.T) {
+	client, mautrixMock := makeClient()
+	roomID, _ := room.NewID("!foo:matrix.test")
+
+	err := client.JoinRoom(roomID)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !mautrixMock.WasRoomJoined("!foo:matrix.test") {
+		t.Errorf("room wasn't joined")
+	}
+}

--- a/model/room/id.go
+++ b/model/room/id.go
@@ -10,6 +10,7 @@ import (
 type ID interface {
 	ID() string
 	IsAlias() bool
+	HomeserverDomain() string
 }
 
 type id struct {
@@ -44,4 +45,8 @@ func (id *id) ID() string {
 
 func (id *id) IsAlias() bool {
 	return strings.HasPrefix(id.value, "#")
+}
+
+func (id *id) HomeserverDomain() string {
+	return strings.Split(id.value, ":")[1]
 }

--- a/model/room/id_test.go
+++ b/model/room/id_test.go
@@ -51,3 +51,11 @@ func TestIsAlias(t *testing.T) {
 		t.Error("id should be an alias")
 	}
 }
+
+func TestHomeserverDomain(t *testing.T) {
+	id, _ := NewID("#room:matrix.test")
+
+	if id.HomeserverDomain() != "matrix.test" {
+		t.Errorf("homeserver domain should be matrix.test, got %s", id.HomeserverDomain())
+	}
+}

--- a/resources/tests/mocks/mautrix_client.go
+++ b/resources/tests/mocks/mautrix_client.go
@@ -13,6 +13,10 @@ type MautrixClientMock interface {
 	Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error)
 	SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error)
 	SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
+	WasMessageSent(text string) bool
+	Sync() error
+	JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
+	WasRoomJoined(roomIDorAlias string) bool
 	ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
 }
 

--- a/resources/tests/mocks/mautrix_client.go
+++ b/resources/tests/mocks/mautrix_client.go
@@ -9,10 +9,23 @@ import (
 	"maunium.net/go/mautrix/id"
 )
 
+type MautrixClientMock interface {
+	Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error)
+	SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error)
+	SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
+	ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
+}
+
 type mockMatrixClient struct {
 	instantiatedBy string
 	msgs           []string
 	roomsJoined    []string
+}
+
+func NewMockMatrixClient(creator string) MautrixClientMock {
+	return &mockMatrixClient{
+		instantiatedBy: creator,
+	}
 }
 
 func (m *mockMatrixClient) Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error) {
@@ -92,10 +105,4 @@ func (m *mockMatrixClient) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespA
 		RoomID:  id.RoomID(strings.Replace(alias.String(), "#", "!", 1)),
 		Servers: []string{"matrix.test"},
 	}, nil
-}
-
-func NewMockMatrixClient(creator string) *mockMatrixClient {
-	return &mockMatrixClient{
-		instantiatedBy: creator,
-	}
 }

--- a/resources/tests/mocks/mautrix_client.go
+++ b/resources/tests/mocks/mautrix_client.go
@@ -1,6 +1,7 @@
 package mocks
 
 import (
+	"context"
 	"errors"
 	"strings"
 
@@ -14,16 +15,18 @@ type MautrixClientMock interface {
 	SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error)
 	SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
 	WasMessageSent(text string) bool
-	Sync() error
 	JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
 	WasRoomJoined(roomIDorAlias string) bool
 	ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
+	SyncWithContextWasCalled() bool
+	SyncWithContext(ctx context.Context) error
 }
 
 type mockMatrixClient struct {
-	instantiatedBy string
-	msgs           []string
-	roomsJoined    []string
+	instantiatedBy        string
+	msgs                  []string
+	roomsJoined           []string
+	syncWithContextCalled bool
 }
 
 func NewMockMatrixClient(creator string) MautrixClientMock {
@@ -79,10 +82,6 @@ func (m *mockMatrixClient) WasMessageSent(text string) bool {
 	return false
 }
 
-func (m *mockMatrixClient) Sync() error {
-	return nil
-}
-
 func (m *mockMatrixClient) JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error) {
 	if roomIDorAlias == "" {
 		return nil, errors.New("")
@@ -109,4 +108,13 @@ func (m *mockMatrixClient) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespA
 		RoomID:  id.RoomID(strings.Replace(alias.String(), "#", "!", 1)),
 		Servers: []string{"matrix.test"},
 	}, nil
+}
+
+func (m *mockMatrixClient) SyncWithContext(ctx context.Context) error {
+	m.syncWithContextCalled = true
+	return nil
+}
+
+func (m *mockMatrixClient) SyncWithContextWasCalled() bool {
+	return m.syncWithContextCalled
 }

--- a/resources/tests/mocks/mautrix_client.go
+++ b/resources/tests/mocks/mautrix_client.go
@@ -22,20 +22,20 @@ type MautrixClientMock interface {
 	SyncWithContext(ctx context.Context) error
 }
 
-type mockMatrixClient struct {
+type mautrixClientMock struct {
 	instantiatedBy        string
 	msgs                  []string
 	roomsJoined           []string
 	syncWithContextCalled bool
 }
 
-func NewMockMatrixClient(creator string) MautrixClientMock {
-	return &mockMatrixClient{
+func NewMautrixClientMock(creator string) MautrixClientMock {
+	return &mautrixClientMock{
 		instantiatedBy: creator,
 	}
 }
 
-func (m *mockMatrixClient) Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error) {
+func (m *mautrixClientMock) Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error) {
 	// assume the best for mock purposes
 	homeserverInfo := mautrix.HomeserverInfo{BaseURL: ""}
 	identityServerInfo := mautrix.IdentityServerInfo{BaseURL: ""}
@@ -51,7 +51,7 @@ func (m *mockMatrixClient) Login(*mautrix.ReqLogin) (*mautrix.RespLogin, error) 
 	}, nil
 }
 
-func (m *mockMatrixClient) SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error) {
+func (m *mautrixClientMock) SendText(roomID id.RoomID, text string) (*mautrix.RespSendEvent, error) {
 	// a specific message is designed to return error
 	if text == "throwerr" {
 		return nil, errors.New("whatever")
@@ -64,7 +64,7 @@ func (m *mockMatrixClient) SendText(roomID id.RoomID, text string) (*mautrix.Res
 	}, nil
 }
 
-func (m *mockMatrixClient) SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error) {
+func (m *mautrixClientMock) SendMessageEvent(roomID id.RoomID, eventType event.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error) {
 	m.msgs = append(m.msgs, contentJSON.(event.MessageEventContent).Body) // store internally for checking, whether this function was called or not
 
 	return &mautrix.RespSendEvent{
@@ -72,7 +72,7 @@ func (m *mockMatrixClient) SendMessageEvent(roomID id.RoomID, eventType event.Ty
 	}, nil
 }
 
-func (m *mockMatrixClient) WasMessageSent(text string) bool {
+func (m *mautrixClientMock) WasMessageSent(text string) bool {
 	for _, v := range m.msgs {
 		if v == text {
 			return true
@@ -82,7 +82,7 @@ func (m *mockMatrixClient) WasMessageSent(text string) bool {
 	return false
 }
 
-func (m *mockMatrixClient) JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error) {
+func (m *mautrixClientMock) JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error) {
 	if roomIDorAlias == "" {
 		return nil, errors.New("")
 	}
@@ -92,7 +92,7 @@ func (m *mockMatrixClient) JoinRoom(roomIDorAlias string, serverName string, con
 	return
 }
 
-func (m *mockMatrixClient) WasRoomJoined(roomIDorAlias string) bool {
+func (m *mautrixClientMock) WasRoomJoined(roomIDorAlias string) bool {
 	for _, v := range m.roomsJoined {
 		if v == roomIDorAlias {
 			return true
@@ -102,7 +102,7 @@ func (m *mockMatrixClient) WasRoomJoined(roomIDorAlias string) bool {
 	return false
 }
 
-func (m *mockMatrixClient) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error) {
+func (m *mautrixClientMock) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error) {
 	// convert #room:matrix.test to !room:matrix.test as part of mock resolution
 	return &mautrix.RespAliasResolve{
 		RoomID:  id.RoomID(strings.Replace(alias.String(), "#", "!", 1)),
@@ -110,11 +110,11 @@ func (m *mockMatrixClient) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespA
 	}, nil
 }
 
-func (m *mockMatrixClient) SyncWithContext(ctx context.Context) error {
+func (m *mautrixClientMock) SyncWithContext(ctx context.Context) error {
 	m.syncWithContextCalled = true
 	return nil
 }
 
-func (m *mockMatrixClient) SyncWithContextWasCalled() bool {
+func (m *mautrixClientMock) SyncWithContextWasCalled() bool {
 	return m.syncWithContextCalled
 }

--- a/resources/tests/mocks/mautrix_syncer.go
+++ b/resources/tests/mocks/mautrix_syncer.go
@@ -1,0 +1,44 @@
+package mocks
+
+import (
+	"maunium.net/go/mautrix"
+	"maunium.net/go/mautrix/event"
+	"maunium.net/go/mautrix/id"
+	"time"
+)
+
+type MautrixSyncerMock interface {
+	mautrix.Syncer
+	mautrix.ExtensibleSyncer
+}
+
+type mockSyncer struct {
+}
+
+func NewMockMatrixSyncer() *mockSyncer {
+	return &mockSyncer{}
+}
+
+func (mock *mockSyncer) ProcessResponse(resp *mautrix.RespSync, since string) error {
+	panic("implement me")
+}
+
+func (mock *mockSyncer) OnFailedSync(res *mautrix.RespSync, err error) (time.Duration, error) {
+	panic("implement me")
+}
+
+func (mock *mockSyncer) GetFilterJSON(userID id.UserID) *mautrix.Filter {
+	panic("implement me")
+}
+
+func (mock *mockSyncer) OnSync(callback mautrix.SyncHandler) {
+	panic("implement me")
+}
+
+func (mock *mockSyncer) OnEvent(callback mautrix.EventHandler) {
+	panic("implement me")
+}
+
+func (mock *mockSyncer) OnEventType(eventType event.Type, callback mautrix.EventHandler) {
+	panic("implement me")
+}


### PR DESCRIPTION
This PR faciliates registering a handler for a given type of event, for example "user was invited to room", whithout exposing mautrix. Aditionally, it implements the `OnRoomInvite()` and `JoinRoom()` methods on the matrix client.

Note this code isn't in use yet, an upcoming PR will use this to do something like the following:

```go
// Automatically join room when currently-authenticated user receives an invite.
matrixClient.OnRoomInvite(func(roomID room.ID) {
	matrixClient.JoinRoom(roomID)
})
```