### PR TITLE
Database seeds

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,3 +19,6 @@ WORKFLOWS_DEF_TOML_FILE=./resources/workflows.toml
 #MATRIX_SERVER_NAME=matrix.test:443
 #MATRIX_USERNAME=morpheus
 #MATRIX_PASSWORD=redpill
+
+# Bots
+#AFKBOT_PASSWORD=abc123

--- a/app/bot/repository.go
+++ b/app/bot/repository.go
@@ -1,6 +1,7 @@
 package bot
 
 import (
+	"errors"
 	"github.com/upper/db/v4"
 	model "neurobot/model/bot"
 )
@@ -24,5 +25,42 @@ func (repository *repository) FindActive() (bots []model.Bot, err error) {
 func (repository *repository) FindByUsername(username string) (bot model.Bot, err error) {
 	result := repository.collection.Find(db.Cond{"username": username})
 	err = result.One(&bot)
+	return
+}
+
+func (repository *repository) Save(bot *model.Bot) (err error) {
+	if bot.ID > 0 {
+		return repository.update(bot)
+	}
+
+	return repository.insert(bot)
+}
+
+func (repository *repository) update(bot *model.Bot) (err error) {
+	if bot.Primary {
+		return errors.New("cannot make a bot the primary bot")
+	}
+
+	var existing model.Bot
+
+	result := repository.collection.Find(bot.ID)
+	if err = result.One(&existing); err != nil {
+		return
+	}
+
+	existing.Username = bot.Username
+	existing.Password = bot.Password
+	existing.Description = bot.Description
+	existing.Active = bot.Active
+
+	return result.Update(existing)
+}
+
+func (repository *repository) insert(bot *model.Bot) (err error) {
+	result, err := repository.collection.Insert(bot)
+	if err == nil {
+		bot.ID = uint64(result.ID().(int64))
+	}
+
 	return
 }

--- a/app/bot/repository_test.go
+++ b/app/bot/repository_test.go
@@ -9,6 +9,62 @@ import (
 	"testing"
 )
 
+func TestInsert(t *testing.T) {
+	database.Test(func(session db.Session) {
+		repository := NewRepository(session)
+
+		bot := model.Bot{
+			Username:    "username-12345",
+			Password:    "password-12345",
+			Description: "foo",
+			Active:      true,
+			Primary:     false,
+		}
+
+		if err := repository.Save(&bot); err != nil {
+			t.Errorf("failed to insert bot: %s", err)
+		}
+
+		var got model.Bot
+		result := session.Collection("bots").Find(db.Cond{"id": bot.ID})
+		if err := result.One(&got); err != nil {
+			t.Errorf("failed to find bot: %s", err)
+		}
+
+		if !reflect.DeepEqual(got, bot) {
+			t.Errorf("unexpected result insert bot")
+		}
+	})
+}
+
+func TestUpdate(t *testing.T) {
+	database.Test(func(session db.Session) {
+		bots := fixtures.Bots(session)
+		repository := NewRepository(session)
+
+		bot := bots["active 1"]
+		bot.Username = "updated username"
+		bot.Password = "updated password"
+		bot.Description = "updated description"
+		bot.Active = false
+		bot.Primary = false
+
+		if err := repository.Save(&bot); err != nil {
+			t.Errorf("failed to update bot: %s", err)
+		}
+
+		var got model.Bot
+		result := session.Collection("bots").Find(db.Cond{"id": bot.ID})
+		if err := result.One(&got); err != nil {
+			t.Errorf("failed to find bot: %s", err)
+		}
+
+		if !reflect.DeepEqual(got, bot) {
+			t.Errorf("unexpected result update bot")
+		}
+	})
+}
+
 func TestFindActive(t *testing.T) {
 	database.Test(func(session db.Session) {
 		bots := fixtures.Bots(session)

--- a/main.go
+++ b/main.go
@@ -13,6 +13,7 @@ import (
 	"neurobot/infrastructure/matrix"
 	"neurobot/infrastructure/toml"
 	b "neurobot/model/bot"
+	"neurobot/resources/seeds"
 	"os"
 	"strconv"
 	"strings"
@@ -61,6 +62,9 @@ func main() {
 	botRepository := botApp.NewRepository(databaseSession)
 	workflowRepository := workflow.NewRepository(databaseSession)
 	workflowStepsRepository := workflowstep.NewRepository(databaseSession)
+
+	// Seed database.
+	seeds.Bots(botRepository)
 
 	// import TOML
 	err = toml.Import(workflowsDefTOMLFile, workflowRepository, workflowStepsRepository)

--- a/model/bot/repository.go
+++ b/model/bot/repository.go
@@ -2,6 +2,9 @@ package bot
 
 // Repository facilitates persistence and retrieval of bots.
 type Repository interface {
+	// Save persists a bot.
+	Save(bot *Bot) error
+
 	// FindActive retrieves all active bots.
 	FindActive() ([]Bot, error)
 

--- a/resources/seeds/bots.go
+++ b/resources/seeds/bots.go
@@ -1,0 +1,45 @@
+package seeds
+
+import (
+	"fmt"
+	"log"
+	"neurobot/model/bot"
+	"os"
+	"strings"
+)
+
+func Bots(repository bot.Repository) {
+	seeds := []bot.Bot{
+		makeBot("afkbot", "Used by afk_notifier and !afk"),
+	}
+
+	for _, seed := range seeds {
+		existing, _ := repository.FindByUsername(seed.Username)
+		if existing.ID > 0 {
+			// Bot already exists, we'll update it.
+			seed.ID = existing.ID
+		}
+
+		err := repository.Save(&seed)
+		if err != nil {
+			log.Fatalf("Failed to seed bots: %s", err)
+		}
+	}
+}
+
+func makeBot(username string, description string) bot.Bot {
+	// The env variable is called, for example, AFKBOT_PASSWORD.
+	passwordEnvName := fmt.Sprintf("%s_PASSWORD", strings.ToUpper(username))
+
+	passwordEnvValue, exists := os.LookupEnv(passwordEnvName)
+	if !exists || passwordEnvValue == "" {
+		log.Fatalf("environment variable %s is not set", passwordEnvName)
+	}
+
+	return bot.Bot{
+		Description: description,
+		Username:    username,
+		Password:    passwordEnvValue,
+		Active:      true,
+	}
+}


### PR DESCRIPTION
This PR presents a proposal to seed the database with a mechanism similar to what we use for fixtures.

This only for bots now but could be extended in the future to other tables if need be.

The bot password is retrieved from `.env` (AFKBOT is the uppercased username):

```
AFKBOT_PASSWORD=abc123
```