### PR TITLE
use sqlite in-memory database for tests

### DIFF
--- a/resources/tests/database/database.go
+++ b/resources/tests/database/database.go
@@ -51,6 +51,7 @@ func Test(fn func(session db.Session)) {
 	})
 }
 
+// MakeTestDatabaseSession creates an in-memory SQLite database to use in running tests
 func MakeTestDatabaseSession() db.Session {
 	settings := sqlite.ConnectionURL{
 		Database: ":memory:",

--- a/resources/tests/database/database.go
+++ b/resources/tests/database/database.go
@@ -2,9 +2,9 @@ package database
 
 import (
 	"errors"
-	"log"
 	"neurobot/infrastructure/database"
 
+	"github.com/apex/log"
 	"github.com/upper/db/v4"
 	"github.com/upper/db/v4/adapter/sqlite"
 )
@@ -20,12 +20,12 @@ func init() {
 
 	session, err := sqlite.Open(settings)
 	if err != nil {
-		log.Fatalf("Failed to connect to test database: %s", err)
+		log.WithError(err).Fatal("Failed to connect to test database")
 	}
 
 	err = database.Migrate(session)
 	if err != nil {
-		log.Fatalf("Failed to run upgrade/migration scripts on test database: %s", err)
+		log.WithError(err).Fatal("Failed to migrate test database")
 	}
 }
 
@@ -63,7 +63,7 @@ func MakeTestDatabaseSession() db.Session {
 
 	session, err := sqlite.Open(settings)
 	if err != nil {
-		log.Fatalf("Failed to connect to test database: %s", err)
+		log.WithError(err).Fatal("Failed to connect to test database")
 	}
 
 	return session

--- a/resources/tests/database/database.go
+++ b/resources/tests/database/database.go
@@ -9,6 +9,26 @@ import (
 	"github.com/upper/db/v4/adapter/sqlite"
 )
 
+func init() {
+	settings := sqlite.ConnectionURL{
+		Database: ":memory:",
+		Options: map[string]string{
+			"mode":  "memory",
+			"cache": "shared",
+		},
+	}
+
+	session, err := sqlite.Open(settings)
+	if err != nil {
+		log.Fatalf("Failed to connect to test database: %s", err)
+	}
+
+	err = database.Migrate(session)
+	if err != nil {
+		log.Fatalf("Failed to run upgrade/migration scripts on test database: %s", err)
+	}
+}
+
 // Test is a "wrapper" for tests that interact with the Database.
 // It wraps the test in a transaction, and rolls it back automatically,
 // since in tests, we never want to commit the transaction.
@@ -45,9 +65,5 @@ func MakeTestDatabaseSession() db.Session {
 		log.Fatalf("Failed to connect to test database: %s", err)
 	}
 
-	err = database.Migrate(session)
-	if err != nil {
-		log.Fatalf("Failed to run upgrade/migration scripts on test database: %s", err)
-	}
 	return session
 }


### PR DESCRIPTION
I wasted a few hours as tests db was dirty state of db migrations from a previous run, so I put in the time to shift the db used for tests to be an in-memory database, so that every test starts with a fresh database state and it guarantees a non-dirty state irrespective of how royally you mess up the database in previous tests run.