### PR TITLE
Command support

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -57,6 +57,11 @@ func (app app) Run() (err error) {
 			}
 		})
 
+	log.WithFields(log.Fields{
+		"port": app.webhookListener.Port(),
+	}).Infof("Starting webhook listener")
+	app.webhookListener.Run() // blocking
+
 	return
 }
 

--- a/app/app.go
+++ b/app/app.go
@@ -4,10 +4,14 @@ import (
 	"fmt"
 	netHttp "net/http"
 	"neurobot/app/bot"
+	"neurobot/app/commands"
 	"neurobot/app/engine"
 	r "neurobot/app/runner"
 	"neurobot/app/runner/afk_notifier"
 	"neurobot/infrastructure/http"
+	"neurobot/model/command"
+	"neurobot/model/message"
+	"neurobot/model/room"
 	w "neurobot/model/workflow"
 	"strings"
 
@@ -19,19 +23,23 @@ type app struct {
 	botRegistry        bot.Registry
 	workflowRepository w.Repository
 	webhookListener    *http.Server
+	commandChannel     <-chan *command.Command
 }
 
+// NewApp returns the instance to run the entire program
 func NewApp(
 	engine engine.Engine,
 	botRegistry bot.Registry,
 	workflowRepository w.Repository,
 	webhookListener *http.Server,
+	commandChannel <-chan *command.Command,
 ) *app {
 	return &app{
 		engine:             engine,
 		botRegistry:        botRegistry,
 		workflowRepository: workflowRepository,
 		webhookListener:    webhookListener,
+		commandChannel:     commandChannel,
 	}
 }
 
@@ -55,12 +63,24 @@ func (app app) Run() (err error) {
 				}).Error("failed to run workflow")
 				return
 			}
-		})
+		},
+	)
 
-	log.WithFields(log.Fields{
-		"port": app.webhookListener.Port(),
-	}).Infof("Starting webhook listener")
-	app.webhookListener.Run() // blocking
+	go func() {
+		log.WithFields(log.Fields{"port": app.webhookListener.Port()}).Info("Starting webhook listener")
+		app.webhookListener.Run() // blocking
+	}()
+
+	// loop over commands as they are invoked and run each of them (blocking since we are looping over a channel)
+	for c := range app.commandChannel {
+		log.WithFields(log.Fields{
+			"command": c.Name,
+			"args":    c.Args,
+			"room":    c.Meta["room"],
+		}).Info("command received")
+
+		go app.runCommand(c)
+	}
 
 	return
 }
@@ -92,4 +112,59 @@ func (app app) runWorkflow(workflow w.Workflow, payload map[string]string) error
 	}()
 
 	return nil
+}
+
+func (app app) runCommand(comm *command.Command) {
+	identifier := "COMMAND_" + strings.ToUpper(comm.Name)
+
+	// create an instance of the command interface
+	var command commands.Command
+	switch strings.ToUpper(comm.Name) {
+	default:
+		command = commands.NewUnrecognized(comm)
+	case "ECHO":
+		command = commands.NewEcho(comm)
+	}
+
+	payload := command.WorkflowPayload() // need payload to access room, even if command is not valid
+
+	if !command.Valid() {
+		payload["message"] = command.UsageHints()
+
+		mc, err := app.botRegistry.GetPrimaryClient()
+		if err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"identifier": identifier,
+			}).Error("responding to invalid command failed")
+			return
+		}
+
+		roomID, _ := room.NewID(payload["room"]) // no need to check for error, is picked up from an event and not a user input
+
+		if err := mc.SendMessage(
+			roomID,
+			message.NewMarkdownMessage(command.UsageHints()),
+		); err != nil {
+			log.WithError(err).WithFields(log.Fields{
+				"identifier": identifier,
+			}).Error("responding to invalid command failed")
+			return
+		}
+	}
+
+	// find workflow associated with this command
+	workflow, err := app.workflowRepository.FindByIdentifier(identifier)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{"identifier": identifier}).Error("no workflow found")
+		return
+	}
+
+	// run workflow
+	err = app.runWorkflow(workflow, payload)
+	if err != nil {
+		log.WithError(err).WithFields(log.Fields{
+			"identifier": identifier,
+			"payload":    payload,
+		}).Error("failed to run workflow")
+	}
 }

--- a/app/app.go
+++ b/app/app.go
@@ -80,15 +80,14 @@ func (app app) runWorkflow(workflow w.Workflow, payload map[string]string) error
 	}
 
 	go func() {
-		log.WithFields(log.Fields{
+		ctx := log.Fields{
 			"identifier": workflow.Identifier,
 			"payload":    payload,
-		}).Info("starting workflow")
+		}
+		log.WithFields(ctx).Info("starting workflow")
 		err := runner.Run(workflow, payload)
 		if err != nil {
-			log.WithError(err).WithFields(log.Fields{
-				"payload": payload,
-			}).Error("failed to run workflow")
+			log.WithError(err).WithFields(ctx).Error("failed to run workflow")
 		}
 	}()
 

--- a/app/bot/registry.go
+++ b/app/bot/registry.go
@@ -57,10 +57,12 @@ func (r *registry) Append(bot model.Bot, client matrix.Client) (err error) {
 		}
 	})
 
-	err = client.OnMessage(func(roomID room.ID, message message.Message) {
-		// log messages received temporarily
-		log.WithFields(log.Fields{"room": roomID, "bot": bot.Username, "message": message.String()}).Info("message received")
-	})
+	if bot.IsPrimary() {
+		err = client.OnMessage(func(roomID room.ID, message message.Message) {
+			// log messages received temporarily
+			log.WithFields(log.Fields{"room": roomID, "bot": bot.Username, "message": message.String()}).Info("message received")
+		})
+	}
 
 	if err != nil {
 		return

--- a/app/commands/commands.go
+++ b/app/commands/commands.go
@@ -1,0 +1,11 @@
+package commands
+
+// Command defines the interface for each command that is to be defined
+type Command interface {
+	// Valid method returns true/false based on whether it has valid data for execution
+	Valid() bool
+	// UsageHints method simply shows an example for command invokation
+	UsageHints() string
+	// Returns the payload prepared internally, since payload comes into existence once command triggers
+	WorkflowPayload() map[string]string
+}

--- a/app/commands/echo.go
+++ b/app/commands/echo.go
@@ -1,0 +1,44 @@
+package commands
+
+import (
+	"neurobot/model/command"
+	"strings"
+)
+
+type echo struct {
+	payload map[string]string
+}
+
+func (e *echo) Valid() bool {
+	if len(e.payload["message"]) == 0 {
+		return false
+	}
+
+	return true
+}
+
+func (e *echo) UsageHints() string {
+	return "Usage: `!echo some text`"
+}
+
+func (e *echo) WorkflowPayload() map[string]string {
+	return e.payload
+}
+
+// NewEcho returns an instance of ECHO command that handles its validation and set defaults for payload
+func NewEcho(comm *command.Command) Command {
+	payload := make(map[string]string)
+
+	// convert args map into an args slice
+	args := make([]string, 0, len(comm.Args))
+	for _, v := range comm.Args {
+		args = append(args, v)
+	}
+
+	payload["message"] = strings.TrimSpace(strings.Join(args, " "))
+	payload["room"] = comm.Meta["room"]
+
+	return &echo{
+		payload: payload,
+	}
+}

--- a/app/commands/unrecognized.go
+++ b/app/commands/unrecognized.go
@@ -1,0 +1,36 @@
+package commands
+
+import (
+	"fmt"
+	"neurobot/model/command"
+)
+
+const unrecognizedCommandUsageHint = "😱 Unrecognized command `!%s` please consult documentation"
+
+type unrecognized struct {
+	commandName string
+	payload     map[string]string
+}
+
+func (u *unrecognized) Valid() bool {
+	return false
+}
+
+func (u *unrecognized) UsageHints() string {
+	return fmt.Sprintf(unrecognizedCommandUsageHint, u.commandName)
+}
+
+func (u *unrecognized) WorkflowPayload() map[string]string {
+	return u.payload
+}
+
+// NewUnrecognized returns an instance of Command meant to be a catch-all for undefined commands invoked
+func NewUnrecognized(comm *command.Command) Command {
+	payload := make(map[string]string)
+	payload["room"] = comm.Meta["room"]
+
+	return &unrecognized{
+		commandName: comm.Name,
+		payload:     payload,
+	}
+}

--- a/infrastructure/http/server.go
+++ b/infrastructure/http/server.go
@@ -37,6 +37,11 @@ func (s *Server) Run() {
 	}
 }
 
+// Port returns port on which server is configured to run
+func (s *Server) Port() int {
+	return s.port
+}
+
 // RegisterRoute saves the callback func for a particular route
 func (s *Server) RegisterRoute(route string, fn requestHandler) error {
 	if _, ok := s.routes[route]; ok {

--- a/infrastructure/matrix/client.go
+++ b/infrastructure/matrix/client.go
@@ -16,4 +16,7 @@ type Client interface {
 	// OnMessage registers a handler that will be called whenever a message is sent to a room
 	// the currently authenticated user is a member of.
 	OnMessage(handler func(roomID room.ID, message message.Message)) error
+
+	// IsCommand returns true if the message passed is an invokation of command
+	IsCommand(message message.Message) bool
 }

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -226,6 +226,21 @@ func (client *client) resolveRoomAlias(roomID room.ID) (mautrixId.RoomID, error)
 	return mautrixId.RoomID(response.RoomID.String()), nil
 }
 
+func (client *client) IsCommand(message msg.Message) bool {
+	words := strings.Fields(strings.TrimSpace(message.String()))
+
+	// shortest command can be "!s"
+	if len(words) == 0 || len(words[0]) < 2 {
+		return false
+	}
+
+	if strings.HasPrefix(words[0], "!") {
+		return true
+	}
+
+	return false
+}
+
 func (client *client) assertListenersEnabled() error {
 	if !client.listenersEnabled {
 		return errors.New("listeners are not enabled. You can enable listeners through the enableListeners argument of NewMautrixClient()")

--- a/infrastructure/matrix/mautrix_client_test.go
+++ b/infrastructure/matrix/mautrix_client_test.go
@@ -1,6 +1,7 @@
 package matrix
 
 import (
+	"neurobot/model/message"
 	msg "neurobot/model/message"
 	"neurobot/model/room"
 	"neurobot/resources/tests/mocks"
@@ -63,4 +64,58 @@ func TestJoinRoom(t *testing.T) {
 	if !mautrixMock.WasRoomJoined("!foo:matrix.test") {
 		t.Errorf("room wasn't joined")
 	}
+}
+
+func TestIsCommand(t *testing.T) {
+	client, _, _ := makeClient()
+
+	tables := []struct {
+		description string
+		msg         string
+		isCommand   bool
+	}{
+		{
+			description: "empty message",
+			msg:         "",
+			isCommand:   false,
+		},
+		{
+			description: "regular message",
+			msg:         "hello john",
+			isCommand:   false,
+		},
+		{
+			description: "command with no arguments",
+			msg:         "!echo",
+			isCommand:   true,
+		},
+		{
+			description: "command with 1 argument",
+			msg:         "!echo sound",
+			isCommand:   true,
+		},
+		{
+			description: "command with arguments",
+			msg:         "!echo sound everywhere",
+			isCommand:   true,
+		},
+		{
+			description: "broken command - missing command name",
+			msg:         "!",
+			isCommand:   false,
+		},
+		{
+			description: "broken command - missing command name but with arguments",
+			msg:         "! sound everywhere",
+			isCommand:   false,
+		},
+	}
+
+	for _, table := range tables {
+		output := client.IsCommand(message.NewPlainTextMessage(table.msg))
+		if table.isCommand != output {
+			t.Errorf("mismatch for [%s] should be %t but is %t", table.description, table.isCommand, output)
+		}
+	}
+
 }

--- a/main.go
+++ b/main.go
@@ -58,11 +58,6 @@ func main() {
 	if err := app.Run(); err != nil {
 		logger.WithError(err).Fatal("Failed to run application")
 	}
-
-	logger.WithFields(log.Fields{
-		"port": config.WebhookListenerPort,
-	}).Infof("Starting webhook listener")
-	webhookListenerServer.Run() // blocking
 }
 
 func makeBotRegistry(serverName string, botRepository b.Repository, db db.Session) (registry botApp.Registry) {

--- a/main.go
+++ b/main.go
@@ -52,9 +52,12 @@ func main() {
 	botRegistry := makeBotRegistry(config.ServerName, botRepository, databaseSession)
 	webhookListenerServer := http.NewServer(config.WebhookListenerPort)
 
-	e := engine.NewEngine(botRegistry, workflowStepsRepository)
-
-	app := application.NewApp(e, botRegistry, workflowRepository, webhookListenerServer)
+	app := application.NewApp(
+		engine.NewEngine(botRegistry, workflowStepsRepository),
+		botRegistry,
+		workflowRepository,
+		webhookListenerServer,
+	)
 	if err := app.Run(); err != nil {
 		logger.WithError(err).Fatal("Failed to run application")
 	}

--- a/model/command/command.go
+++ b/model/command/command.go
@@ -7,16 +7,16 @@ import (
 
 // Command represents a command invoked in a message for a particular bot to react
 type Command struct {
-	command string
-	args    map[string]string
+	Name string
+	Args map[string]string
 }
 
 func (c *Command) String() string {
-	arguments := make([]string, 0, len(c.args))
-	for _, arg := range c.args {
+	arguments := make([]string, 0, len(c.Args))
+	for _, arg := range c.Args {
 		arguments = append(arguments, arg)
 	}
-	return fmt.Sprintf("!%s %s", c.command, strings.Join(arguments, " "))
+	return fmt.Sprintf("!%s %s", c.Name, strings.Join(arguments, " "))
 }
 
 // NewCommand creates an instance of representation of Command (name + arguments)
@@ -30,7 +30,7 @@ func NewCommand(msg string) *Command {
 	}
 
 	return &Command{
-		command: words[0],
-		args:    args,
+		Name: words[0],
+		Args: args,
 	}
 }

--- a/model/command/command.go
+++ b/model/command/command.go
@@ -9,6 +9,7 @@ import (
 type Command struct {
 	Name string
 	Args map[string]string
+	Meta map[string]string
 }
 
 func (c *Command) String() string {
@@ -30,7 +31,8 @@ func NewCommand(msg string) *Command {
 	}
 
 	return &Command{
-		Name: words[0],
+		Name: strings.TrimLeft(words[0], "!"),
 		Args: args,
+		Meta: make(map[string]string),
 	}
 }

--- a/model/command/command.go
+++ b/model/command/command.go
@@ -25,7 +25,7 @@ func NewCommand(msg string) *Command {
 
 	args := make(map[string]string)
 	for index, word := range words[1:] {
-		argName := fmt.Sprintf("arg%d", index)
+		argName := fmt.Sprintf("arg%d", index+1)
 		args[argName] = word
 	}
 

--- a/model/command/command.go
+++ b/model/command/command.go
@@ -1,0 +1,36 @@
+package command
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Command represents a command invoked in a message for a particular bot to react
+type Command struct {
+	command string
+	args    map[string]string
+}
+
+func (c *Command) String() string {
+	arguments := make([]string, 0, len(c.args))
+	for _, arg := range c.args {
+		arguments = append(arguments, arg)
+	}
+	return fmt.Sprintf("!%s %s", c.command, strings.Join(arguments, " "))
+}
+
+// NewCommand creates an instance of representation of Command (name + arguments)
+func NewCommand(msg string) *Command {
+	words := strings.Fields(msg)
+
+	args := make(map[string]string)
+	for index, word := range words[1:] {
+		argName := fmt.Sprintf("arg%d", index)
+		args[argName] = word
+	}
+
+	return &Command{
+		command: words[0],
+		args:    args,
+	}
+}


### PR DESCRIPTION
Adds support for commands (PR optimized for commit by commit review) fixes #108 

- changes the blocking mechanism of app.Run()
- webhooklistener server is now moved into app.Run() but in its own go routine
- indefinitely looping over commands that are invoked which is what makes app.Run() blocking now (this is a good thing for server to gracefully shutdown)
- defines `Command` interface that every command would have to implement, supports validating params and responding with usage hints of each command
- uses command channel as a way of passing commands when they are detected inside bot registry (bot /sync calls) to the right place inside app for execution
- only neurobot is listening to messages
- implements `echo` command as a sample command and `unrecognized` command that acts as a fallback
- commands support multiple params to be passed with space (and we can ofcourse customize this, if desired)