### PR TITLE
Polyglots command + fetchDataExternal workflow step

### DIFF
--- a/app/app.go
+++ b/app/app.go
@@ -125,6 +125,8 @@ func (app app) runCommand(comm *command.Command) {
 		command = commands.NewUnrecognized(comm)
 	case "ECHO":
 		command = commands.NewEcho(comm)
+	case "POLYGLOTS":
+		command = commands.NewPolyglots(comm)
 	}
 
 	payload := command.WorkflowPayload() // need payload to access room, even if command is not valid

--- a/app/app.go
+++ b/app/app.go
@@ -11,6 +11,7 @@ import (
 	"neurobot/infrastructure/http"
 	"neurobot/model/command"
 	"neurobot/model/message"
+	"neurobot/model/payload"
 	"neurobot/model/room"
 	w "neurobot/model/workflow"
 	"strings"
@@ -46,7 +47,7 @@ func NewApp(
 func (app app) Run() (err error) {
 	err = app.webhookListener.RegisterRoute(
 		"/",
-		func(response netHttp.ResponseWriter, request *netHttp.Request, payload map[string]string) {
+		func(response netHttp.ResponseWriter, request *netHttp.Request, payload payload.Payload) {
 			workflowIdentifier := strings.TrimPrefix(request.URL.Path, "/")
 			workflow, err := app.workflowRepository.FindByIdentifier(workflowIdentifier)
 			if err != nil {
@@ -85,7 +86,7 @@ func (app app) Run() (err error) {
 	return
 }
 
-func (app app) runWorkflow(workflow w.Workflow, payload map[string]string) error {
+func (app app) runWorkflow(workflow w.Workflow, payload payload.Payload) error {
 	var runner r.Runner
 
 	switch workflow.Identifier {
@@ -129,7 +130,7 @@ func (app app) runCommand(comm *command.Command) {
 	payload := command.WorkflowPayload() // need payload to access room, even if command is not valid
 
 	if !command.Valid() {
-		payload["message"] = command.UsageHints()
+		payload.Message = command.UsageHints()
 
 		mc, err := app.botRegistry.GetPrimaryClient()
 		if err != nil {
@@ -139,7 +140,7 @@ func (app app) runCommand(comm *command.Command) {
 			return
 		}
 
-		roomID, _ := room.NewID(payload["room"]) // no need to check for error, is picked up from an event and not a user input
+		roomID, _ := room.NewID(payload.Room) // no need to check for error, is picked up from an event and not a user input
 
 		if err := mc.SendMessage(
 			roomID,

--- a/app/commands/commands.go
+++ b/app/commands/commands.go
@@ -1,5 +1,7 @@
 package commands
 
+import "neurobot/model/payload"
+
 // Command defines the interface for each command that is to be defined
 type Command interface {
 	// Valid method returns true/false based on whether it has valid data for execution
@@ -7,5 +9,5 @@ type Command interface {
 	// UsageHints method simply shows an example for command invokation
 	UsageHints() string
 	// Returns the payload prepared internally, since payload comes into existence once command triggers
-	WorkflowPayload() map[string]string
+	WorkflowPayload() payload.Payload
 }

--- a/app/commands/echo.go
+++ b/app/commands/echo.go
@@ -2,15 +2,16 @@ package commands
 
 import (
 	"neurobot/model/command"
+	"neurobot/model/payload"
 	"strings"
 )
 
 type echo struct {
-	payload map[string]string
+	payload payload.Payload
 }
 
 func (e *echo) Valid() bool {
-	if len(e.payload["message"]) == 0 {
+	if len(e.payload.Message) == 0 {
 		return false
 	}
 
@@ -21,13 +22,13 @@ func (e *echo) UsageHints() string {
 	return "Usage: `!echo some text`"
 }
 
-func (e *echo) WorkflowPayload() map[string]string {
+func (e *echo) WorkflowPayload() payload.Payload {
 	return e.payload
 }
 
 // NewEcho returns an instance of ECHO command that handles its validation and set defaults for payload
 func NewEcho(comm *command.Command) Command {
-	payload := make(map[string]string)
+	var payload payload.Payload
 
 	// convert args map into an args slice
 	args := make([]string, 0, len(comm.Args))
@@ -35,8 +36,8 @@ func NewEcho(comm *command.Command) Command {
 		args = append(args, v)
 	}
 
-	payload["message"] = strings.TrimSpace(strings.Join(args, " "))
-	payload["room"] = comm.Meta["room"]
+	payload.Message = strings.TrimSpace(strings.Join(args, " "))
+	payload.Room = comm.Meta["room"]
 
 	return &echo{
 		payload: payload,

--- a/app/commands/polyglots.go
+++ b/app/commands/polyglots.go
@@ -1,0 +1,43 @@
+package commands
+
+import (
+	"fmt"
+	"neurobot/model/command"
+	"neurobot/model/payload"
+)
+
+type polyglots struct {
+	payload payload.Payload
+}
+
+func (p *polyglots) Valid() bool {
+	return true
+}
+
+func (p *polyglots) UsageHints() string {
+	return "Usage: `!polyglots spanish`"
+}
+
+func (p *polyglots) WorkflowPayload() payload.Payload {
+	return p.payload
+}
+
+// NewPolyglots returns an instance of POLYGLOTS command that handles its validation and set defaults for payload
+func NewPolyglots(comm *command.Command) Command {
+	var pg polyglots
+	pg.payload.Room = comm.Meta["room"]
+
+	// convert args map into an args slice
+	args := make([]string, 0, len(comm.Args))
+	for _, v := range comm.Args {
+		args = append(args, v)
+	}
+
+	pg.payload.Context = make(map[string]string)
+	pg.payload.Context["postParam1Name"] = "lang"
+	pg.payload.Context["postParam1Value"] = args[0]
+
+	pg.payload.Message = fmt.Sprintf("Folks who know '%s' and are online: ", args[0])
+
+	return &pg
+}

--- a/app/commands/unrecognized.go
+++ b/app/commands/unrecognized.go
@@ -3,13 +3,14 @@ package commands
 import (
 	"fmt"
 	"neurobot/model/command"
+	"neurobot/model/payload"
 )
 
 const unrecognizedCommandUsageHint = "😱 Unrecognized command `!%s` please consult documentation"
 
 type unrecognized struct {
 	commandName string
-	payload     map[string]string
+	payload     payload.Payload
 }
 
 func (u *unrecognized) Valid() bool {
@@ -20,14 +21,14 @@ func (u *unrecognized) UsageHints() string {
 	return fmt.Sprintf(unrecognizedCommandUsageHint, u.commandName)
 }
 
-func (u *unrecognized) WorkflowPayload() map[string]string {
+func (u *unrecognized) WorkflowPayload() payload.Payload {
 	return u.payload
 }
 
 // NewUnrecognized returns an instance of Command meant to be a catch-all for undefined commands invoked
 func NewUnrecognized(comm *command.Command) Command {
-	payload := make(map[string]string)
-	payload["room"] = comm.Meta["room"]
+	var payload payload.Payload
+	payload.Room = comm.Meta["room"]
 
 	return &unrecognized{
 		commandName: comm.Name,

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -47,9 +47,9 @@ func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 		case "postMatrixMessage":
 			runners = append(runners, s.NewPostMatrixMessageRunner(step.Meta, e.botRegistry))
 		case "stdOut":
-			runners = append(runners, s.NewStdOutRunner(step.Meta, e.botRegistry))
+			runners = append(runners, s.NewStdOutRunner(step.Meta))
 		case "fetchDataExternal":
-			runners = append(runners, s.NewFetchDataExternalRunner(step.Meta, e.botRegistry))
+			runners = append(runners, s.NewFetchDataExternalRunner(step.Meta))
 		}
 	}
 

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -48,10 +48,12 @@ func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 			runners = append(runners, s.NewPostMatrixMessageRunner(step.Meta, e.botRegistry))
 		case "stdOut":
 			runners = append(runners, s.NewStdOutRunner(step.Meta, e.botRegistry))
+		case "fetchDataExternal":
+			runners = append(runners, s.NewFetchDataExternalRunner(step.Meta, e.botRegistry))
 		}
 	}
 
-	for _, r := range runners {
+	for index, r := range runners {
 		err = r.Run(&payload)
 		if err != nil {
 			// For now, we don't halt the workflow if a workflow step encounters an error
@@ -59,6 +61,10 @@ func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 				"Identifier": w.Identifier,
 			}).Info("workflow step execution error")
 		}
+		logger.WithFields(log.Fields{
+			"index":   index,
+			"payload": payload,
+		}).Info("payload after step execution")
 	}
 
 	return nil

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"neurobot/app/bot"
 	s "neurobot/app/engine/steps"
+	"neurobot/model/payload"
 	wf "neurobot/model/workflow"
 	wfs "neurobot/model/workflowstep"
 
@@ -11,11 +12,11 @@ import (
 )
 
 type Engine interface {
-	Run(wf.Workflow, map[string]string) error
+	Run(wf.Workflow, payload.Payload) error
 }
 
 type WorkflowStepRunner interface {
-	Run(map[string]string) (map[string]string, error) // accepts payload and returns after modification (if desired)
+	Run(payload.Payload) (payload.Payload, error) // accepts payload and returns after modification (if desired)
 }
 
 type engine struct {
@@ -30,7 +31,7 @@ func NewEngine(botRegistry bot.Registry, workflowStepRepository wfs.Repository) 
 	}
 }
 
-func (e *engine) Run(w wf.Workflow, payload map[string]string) error {
+func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 	logger := log.Log
 
 	// loop through all the steps inside of the workflow

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -16,7 +16,7 @@ type Engine interface {
 }
 
 type WorkflowStepRunner interface {
-	Run(payload.Payload) (payload.Payload, error) // accepts payload and returns after modification (if desired)
+	Run(*payload.Payload) error // accepts payload pointer (for easy modification)
 }
 
 type engine struct {
@@ -52,7 +52,7 @@ func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 	}
 
 	for _, r := range runners {
-		payload, err = r.Run(payload)
+		err = r.Run(&payload)
 		if err != nil {
 			// For now, we don't halt the workflow if a workflow step encounters an error
 			logger.WithError(err).WithFields(log.Fields{

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -50,6 +50,8 @@ func (e *engine) Run(w wf.Workflow, payload payload.Payload) error {
 			runners = append(runners, s.NewStdOutRunner(step.Meta))
 		case "fetchDataExternal":
 			runners = append(runners, s.NewFetchDataExternalRunner(step.Meta))
+		case "formatMessage":
+			runners = append(runners, s.NewFormatMessageRunner(step.Meta))
 		}
 	}
 

--- a/app/engine/steps/fetch_data_external.go
+++ b/app/engine/steps/fetch_data_external.go
@@ -1,0 +1,62 @@
+package steps
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	botApp "neurobot/app/bot"
+	"time"
+
+	"neurobot/model/payload"
+)
+
+type fetchDataExternalMeta struct {
+	url string
+}
+
+type fetchDataExternalWorkflowStepRunner struct {
+	fetchDataExternalMeta
+	botRegistry botApp.Registry
+}
+
+func (runner fetchDataExternalWorkflowStepRunner) Run(p *payload.Payload) error {
+	j, err := json.Marshal(&p)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", runner.url, bytes.NewBuffer(j))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Auth", "secret") // @TODO move this to config
+
+	client := &http.Client{}
+	client.Timeout = time.Second * 120
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		return err
+	}
+
+	// overwrite payload and return
+	json.NewDecoder(resp.Body).Decode(&p)
+	return nil
+}
+
+// NewFetchDataExternalRunner returns an instance of worklow step for fetching data from an external source
+func NewFetchDataExternalRunner(meta map[string]string, botRegistry botApp.Registry) *fetchDataExternalWorkflowStepRunner {
+	var stepMeta fetchDataExternalMeta
+
+	stepMeta.url, _ = meta["url"]
+
+	return &fetchDataExternalWorkflowStepRunner{
+		fetchDataExternalMeta: stepMeta,
+		botRegistry:           botRegistry,
+	}
+}

--- a/app/engine/steps/fetch_data_external.go
+++ b/app/engine/steps/fetch_data_external.go
@@ -19,7 +19,7 @@ type fetchDataExternalWorkflowStepRunner struct {
 	botRegistry botApp.Registry
 }
 
-func (runner fetchDataExternalWorkflowStepRunner) Run(p *payload.Payload) error {
+func (runner *fetchDataExternalWorkflowStepRunner) Run(p *payload.Payload) error {
 	j, err := json.Marshal(&p)
 	if err != nil {
 		return err

--- a/app/engine/steps/fetch_data_external.go
+++ b/app/engine/steps/fetch_data_external.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"net/http"
-	botApp "neurobot/app/bot"
 	"time"
 
 	"neurobot/model/payload"
@@ -16,7 +15,6 @@ type fetchDataExternalMeta struct {
 
 type fetchDataExternalWorkflowStepRunner struct {
 	fetchDataExternalMeta
-	botRegistry botApp.Registry
 }
 
 func (runner *fetchDataExternalWorkflowStepRunner) Run(p *payload.Payload) error {
@@ -50,13 +48,8 @@ func (runner *fetchDataExternalWorkflowStepRunner) Run(p *payload.Payload) error
 }
 
 // NewFetchDataExternalRunner returns an instance of worklow step for fetching data from an external source
-func NewFetchDataExternalRunner(meta map[string]string, botRegistry botApp.Registry) *fetchDataExternalWorkflowStepRunner {
+func NewFetchDataExternalRunner(meta map[string]string) *fetchDataExternalWorkflowStepRunner {
 	var stepMeta fetchDataExternalMeta
-
 	stepMeta.url, _ = meta["url"]
-
-	return &fetchDataExternalWorkflowStepRunner{
-		fetchDataExternalMeta: stepMeta,
-		botRegistry:           botRegistry,
-	}
+	return &fetchDataExternalWorkflowStepRunner{stepMeta}
 }

--- a/app/engine/steps/format_message.go
+++ b/app/engine/steps/format_message.go
@@ -1,0 +1,28 @@
+package steps
+
+import (
+	"fmt"
+	"neurobot/model/payload"
+)
+
+type formatMessageWorkflowStepMeta struct {
+	variety string
+}
+
+type formatMessageWorkflowStepRunner struct {
+	formatMessageWorkflowStepMeta
+}
+
+func (runner *formatMessageWorkflowStepRunner) Run(p *payload.Payload) error {
+	switch runner.variety {
+	case "appendUsersList":
+		p.Message = p.Message + fmt.Sprintf("%+q", p.Users)
+	}
+	return nil
+}
+
+func NewFormatMessageRunner(meta map[string]string) *formatMessageWorkflowStepRunner {
+	var stepMeta formatMessageWorkflowStepMeta
+	stepMeta.variety, _ = meta["variety"]
+	return &formatMessageWorkflowStepRunner{stepMeta}
+}

--- a/app/engine/steps/post_matrix_message.go
+++ b/app/engine/steps/post_matrix_message.go
@@ -30,7 +30,7 @@ func (runner postMatrixMessageWorkflowStepRunner) getMatrixClient() (mc matrix.C
 	return runner.botRegistry.GetClient(runner.asBot)
 }
 
-func (runner postMatrixMessageWorkflowStepRunner) Run(p payload.Payload) (payload.Payload, error) {
+func (runner postMatrixMessageWorkflowStepRunner) Run(p *payload.Payload) error {
 	msg := p.Message
 
 	// Append message specified in definition of this step as a prefix to the payload
@@ -50,25 +50,25 @@ func (runner postMatrixMessageWorkflowStepRunner) Run(p payload.Payload) (payloa
 
 	// ensure we have data to work with
 	if room == "" {
-		return p, errors.New("no room to post")
+		return errors.New("no room to post")
 	}
 	if msg == "" {
-		return p, errors.New("no message to post")
+		return errors.New("no message to post")
 	}
 
 	mc, err := runner.getMatrixClient()
 	if err != nil {
-		return p, err
+		return err
 	}
 
 	roomID, err := r.NewID(room)
 	if err != nil {
-		return p, err
+		return err
 	}
 
 	err = mc.SendMessage(roomID, message.NewMarkdownMessage(msg))
 
-	return p, err
+	return err
 }
 
 func NewPostMatrixMessageRunner(meta map[string]string, botRegistry botApp.Registry) *postMatrixMessageWorkflowStepRunner {

--- a/app/engine/steps/post_matrix_message.go
+++ b/app/engine/steps/post_matrix_message.go
@@ -66,9 +66,7 @@ func (runner *postMatrixMessageWorkflowStepRunner) Run(p *payload.Payload) error
 		return err
 	}
 
-	err = mc.SendMessage(roomID, message.NewMarkdownMessage(msg))
-
-	return err
+	return mc.SendMessage(roomID, message.NewMarkdownMessage(msg))
 }
 
 func NewPostMatrixMessageRunner(meta map[string]string, botRegistry botApp.Registry) *postMatrixMessageWorkflowStepRunner {

--- a/app/engine/steps/post_matrix_message.go
+++ b/app/engine/steps/post_matrix_message.go
@@ -6,6 +6,7 @@ import (
 	botApp "neurobot/app/bot"
 	"neurobot/infrastructure/matrix"
 	"neurobot/model/message"
+	"neurobot/model/payload"
 	r "neurobot/model/room"
 )
 
@@ -29,13 +30,13 @@ func (runner postMatrixMessageWorkflowStepRunner) getMatrixClient() (mc matrix.C
 	return runner.botRegistry.GetClient(runner.asBot)
 }
 
-func (runner postMatrixMessageWorkflowStepRunner) Run(p map[string]string) (map[string]string, error) {
-	msg := p["message"]
+func (runner postMatrixMessageWorkflowStepRunner) Run(p payload.Payload) (payload.Payload, error) {
+	msg := p.Message
 
 	// Append message specified in definition of this step as a prefix to the payload
 	if runner.messagePrefix != "" {
-		if p["message"] != "" {
-			msg = fmt.Sprintf("%s %s", runner.messagePrefix, p["message"])
+		if p.Message != "" {
+			msg = fmt.Sprintf("%s %s", runner.messagePrefix, p.Message)
 		} else {
 			msg = runner.messagePrefix
 		}
@@ -43,8 +44,8 @@ func (runner postMatrixMessageWorkflowStepRunner) Run(p map[string]string) (map[
 
 	// Override room defined in meta, if provided in payload
 	room := runner.room
-	if p["room"] != "" {
-		room = p["room"]
+	if p.Room != "" {
+		room = p.Room
 	}
 
 	// ensure we have data to work with

--- a/app/engine/steps/post_matrix_message.go
+++ b/app/engine/steps/post_matrix_message.go
@@ -21,7 +21,7 @@ type postMatrixMessageWorkflowStepRunner struct {
 	botRegistry botApp.Registry
 }
 
-func (runner postMatrixMessageWorkflowStepRunner) getMatrixClient() (mc matrix.Client, err error) {
+func (runner *postMatrixMessageWorkflowStepRunner) getMatrixClient() (mc matrix.Client, err error) {
 	if runner.asBot == "" {
 		// If no bot was specified, use the primary one.
 		return runner.botRegistry.GetPrimaryClient()
@@ -30,7 +30,7 @@ func (runner postMatrixMessageWorkflowStepRunner) getMatrixClient() (mc matrix.C
 	return runner.botRegistry.GetClient(runner.asBot)
 }
 
-func (runner postMatrixMessageWorkflowStepRunner) Run(p *payload.Payload) error {
+func (runner *postMatrixMessageWorkflowStepRunner) Run(p *payload.Payload) error {
 	msg := p.Message
 
 	// Append message specified in definition of this step as a prefix to the payload

--- a/app/engine/steps/stdout.go
+++ b/app/engine/steps/stdout.go
@@ -5,7 +5,6 @@ import (
 	"io"
 	"os"
 
-	botApp "neurobot/app/bot"
 	"neurobot/model/payload"
 )
 
@@ -23,6 +22,6 @@ func (runner *stdoutWorkflowStepRunner) Run(p *payload.Payload) error {
 	return nil
 }
 
-func NewStdOutRunner(meta map[string]string, botRegistry botApp.Registry) *stdoutWorkflowStepRunner {
+func NewStdOutRunner(meta map[string]string) *stdoutWorkflowStepRunner {
 	return &stdoutWorkflowStepRunner{}
 }

--- a/app/engine/steps/stdout.go
+++ b/app/engine/steps/stdout.go
@@ -6,14 +6,15 @@ import (
 	"os"
 
 	botApp "neurobot/app/bot"
+	"neurobot/model/payload"
 )
 
 var out io.Writer = os.Stdout
 
 type stdoutWorkflowStepRunner struct{}
 
-func (runner stdoutWorkflowStepRunner) Run(p map[string]string) (map[string]string, error) {
-	msg := p["message"]
+func (runner stdoutWorkflowStepRunner) Run(p payload.Payload) (payload.Payload, error) {
+	msg := p.Message
 	if msg == "" {
 		msg = "[Empty line]"
 	}

--- a/app/engine/steps/stdout.go
+++ b/app/engine/steps/stdout.go
@@ -13,14 +13,14 @@ var out io.Writer = os.Stdout
 
 type stdoutWorkflowStepRunner struct{}
 
-func (runner stdoutWorkflowStepRunner) Run(p payload.Payload) (payload.Payload, error) {
+func (runner stdoutWorkflowStepRunner) Run(p *payload.Payload) error {
 	msg := p.Message
 	if msg == "" {
 		msg = "[Empty line]"
 	}
 	fmt.Fprintln(out, ">>"+msg)
 
-	return p, nil
+	return nil
 }
 
 func NewStdOutRunner(meta map[string]string, botRegistry botApp.Registry) *stdoutWorkflowStepRunner {

--- a/app/engine/steps/stdout.go
+++ b/app/engine/steps/stdout.go
@@ -13,7 +13,7 @@ var out io.Writer = os.Stdout
 
 type stdoutWorkflowStepRunner struct{}
 
-func (runner stdoutWorkflowStepRunner) Run(p *payload.Payload) error {
+func (runner *stdoutWorkflowStepRunner) Run(p *payload.Payload) error {
 	msg := p.Message
 	if msg == "" {
 		msg = "[Empty line]"

--- a/app/engine/steps/stdout_test.go
+++ b/app/engine/steps/stdout_test.go
@@ -29,7 +29,7 @@ func TestStdoutWorkflowStep(t *testing.T) {
 	for _, table := range tables {
 		s := &stdoutWorkflowStepRunner{}
 
-		s.Run(payload.Payload{
+		s.Run(&payload.Payload{
 			Message: table.input,
 		})
 

--- a/app/engine/steps/stdout_test.go
+++ b/app/engine/steps/stdout_test.go
@@ -2,6 +2,7 @@ package steps
 
 import (
 	"bytes"
+	"neurobot/model/payload"
 	"testing"
 )
 
@@ -27,7 +28,10 @@ func TestStdoutWorkflowStep(t *testing.T) {
 
 	for _, table := range tables {
 		s := &stdoutWorkflowStepRunner{}
-		s.Run(map[string]string{"message": table.input})
+
+		s.Run(payload.Payload{
+			Message: table.input,
+		})
 
 		got := out.(*bytes.Buffer).String()
 		if got != table.output+"\n" {

--- a/app/runner/afk_notifier/runner.go
+++ b/app/runner/afk_notifier/runner.go
@@ -4,6 +4,7 @@ import (
 	r "neurobot/app/runner"
 	"neurobot/infrastructure/matrix"
 	m "neurobot/model/message"
+	"neurobot/model/payload"
 	"neurobot/model/room"
 	"neurobot/model/workflow"
 )
@@ -16,13 +17,13 @@ func NewRunner(matrixClient matrix.Client) r.Runner {
 	return &runner{matrixClient: matrixClient}
 }
 
-func (r *runner) Run(workflow workflow.Workflow, payload map[string]string) error {
-	roomID, err := room.NewID(payload["room"])
+func (r *runner) Run(workflow workflow.Workflow, payload payload.Payload) error {
+	roomID, err := room.NewID(payload.Room)
 	if err != nil {
 		return err
 	}
 
-	message := m.NewMarkdownMessage(payload["message"])
+	message := m.NewMarkdownMessage(payload.Message)
 
 	return r.matrixClient.SendMessage(roomID, message)
 }

--- a/app/runner/runner.go
+++ b/app/runner/runner.go
@@ -1,10 +1,11 @@
 package runner
 
 import (
+	"neurobot/model/payload"
 	"neurobot/model/workflow"
 )
 
 // Runner runs a Workflow with an incoming payload.
 type Runner interface {
-	Run(workflow workflow.Workflow, payload map[string]string) error
+	Run(workflow workflow.Workflow, payload payload.Payload) error
 }

--- a/model/payload/payload.go
+++ b/model/payload/payload.go
@@ -1,0 +1,13 @@
+package payload
+
+// Payload represents the data based on which workflows run, passing this data through each workflow step
+type Payload struct {
+	// what matrix rooms should the message be posted to
+	Room string // this might be better of as plural, need to revisit soon
+	// what matrix users are relevant for this workflow
+	Users []string
+	// what message is to be posted in matrix room or elsewhere
+	Message string
+	// additional contextual parameters
+	Context map[string]string
+}


### PR DESCRIPTION
(PR optimized for commit by commit review)

This PR carries requisites for supporting polyglots workflow

- Defines payload to be a proper struct instead of map[string]string and the associated refactoring
- Implement `POLYGLOTS` command
- payload is now passed between workflow steps as a pointer
- Defines `fetchDataExternal` workflow step that can ping a specified URL with data and update payload as per data returned from it
- Defines `formatMessage` workflow step that can transform `message` property of payload as per the payload (useful right before posting the message)
- change existing workflow steps' methods to be pointer receivers