### PR TITLE
onlineUsersFilter workflow step

### DIFF
--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -47,13 +47,13 @@ func (e *engine) Run(eid string, w wf.Workflow, payload payload.Payload) error {
 		case "postMatrixMessage":
 			runners = append(runners, s.NewPostMatrixMessageRunner(eid, step.Meta, e.botRegistry))
 		case "stdOut":
-			runners = append(runners, s.NewStdOutRunner(eid, step.Meta))
+			runners = append(runners, s.NewStdOutRunner(eid))
 		case "fetchDataExternal":
 			runners = append(runners, s.NewFetchDataExternalRunner(eid, step.Meta))
 		case "formatMessage":
 			runners = append(runners, s.NewFormatMessageRunner(eid, step.Meta))
 		case "filterOnlineUsers":
-			runners = append(runners, s.NewFilterOnlineUsers(eid, step.Meta, e.botRegistry))
+			runners = append(runners, s.NewFilterOnlineUsers(eid, e.botRegistry))
 		}
 	}
 

--- a/app/engine/engine.go
+++ b/app/engine/engine.go
@@ -52,6 +52,8 @@ func (e *engine) Run(eid string, w wf.Workflow, payload payload.Payload) error {
 			runners = append(runners, s.NewFetchDataExternalRunner(eid, step.Meta))
 		case "formatMessage":
 			runners = append(runners, s.NewFormatMessageRunner(eid, step.Meta))
+		case "filterOnlineUsers":
+			runners = append(runners, s.NewFilterOnlineUsers(eid, step.Meta, e.botRegistry))
 		}
 	}
 

--- a/app/engine/steps/filter_online_users.go
+++ b/app/engine/steps/filter_online_users.go
@@ -1,0 +1,44 @@
+package steps
+
+import (
+	botApp "neurobot/app/bot"
+	"neurobot/model/payload"
+
+	"github.com/apex/log"
+)
+
+type filterOnlineUsersRunner struct {
+	eid         string
+	botRegistry botApp.Registry
+}
+
+func (runner *filterOnlineUsersRunner) Run(p *payload.Payload) error {
+	log.Log.WithFields(log.Fields{
+		"executionID":  runner.eid,
+		"workflowStep": "filterOnlineUsers",
+	}).Info("running workflow step")
+
+	mc, err := runner.botRegistry.GetPrimaryClient()
+	if err != nil {
+		return err
+	}
+
+	// loop through all users and get their presence status
+	var onlineUsers []string
+	for _, u := range p.Users {
+		if mc.GetPresence(u) == "online" {
+			onlineUsers = append(onlineUsers, u)
+		}
+	}
+
+	p.Users = onlineUsers // effectively removing non-online users (offline or unknown)
+
+	return nil
+}
+
+func NewFilterOnlineUsers(eid string, meta map[string]string, botRegistry botApp.Registry) *filterOnlineUsersRunner {
+	return &filterOnlineUsersRunner{
+		eid:         eid,
+		botRegistry: botRegistry,
+	}
+}

--- a/app/engine/steps/filter_online_users.go
+++ b/app/engine/steps/filter_online_users.go
@@ -36,7 +36,7 @@ func (runner *filterOnlineUsersRunner) Run(p *payload.Payload) error {
 	return nil
 }
 
-func NewFilterOnlineUsers(eid string, meta map[string]string, botRegistry botApp.Registry) *filterOnlineUsersRunner {
+func NewFilterOnlineUsers(eid string, botRegistry botApp.Registry) *filterOnlineUsersRunner {
 	return &filterOnlineUsersRunner{
 		eid:         eid,
 		botRegistry: botRegistry,

--- a/app/engine/steps/stdout.go
+++ b/app/engine/steps/stdout.go
@@ -31,7 +31,7 @@ func (runner *stdoutWorkflowStepRunner) Run(p *payload.Payload) error {
 	return nil
 }
 
-func NewStdOutRunner(eid string, meta map[string]string) *stdoutWorkflowStepRunner {
+func NewStdOutRunner(eid string) *stdoutWorkflowStepRunner {
 	return &stdoutWorkflowStepRunner{
 		eid: eid,
 	}

--- a/infrastructure/matrix/client.go
+++ b/infrastructure/matrix/client.go
@@ -17,6 +17,9 @@ type Client interface {
 	// the currently authenticated user is a member of.
 	OnMessage(handler func(roomID room.ID, message message.Message)) error
 
+	// GetPresence fetches the presence state of the specified user, defaulting to offline
+	GetPresence(userID string) string
+
 	// IsCommand returns true if the message passed is an invokation of command
 	IsCommand(message message.Message) bool
 }

--- a/infrastructure/matrix/mautrix_client.go
+++ b/infrastructure/matrix/mautrix_client.go
@@ -16,6 +16,7 @@ import (
 	"maunium.net/go/mautrix"
 	mautrixEvent "maunium.net/go/mautrix/event"
 	"maunium.net/go/mautrix/format"
+	"maunium.net/go/mautrix/id"
 	mautrixId "maunium.net/go/mautrix/id"
 )
 
@@ -24,6 +25,7 @@ type mautrixClient interface {
 	JoinRoom(roomIDorAlias, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
 	SendText(roomID mautrixId.RoomID, text string) (*mautrix.RespSendEvent, error)
 	SendMessageEvent(roomID mautrixId.RoomID, eventType mautrixEvent.Type, contentJSON interface{}, extra ...mautrix.ReqSendEvent) (resp *mautrix.RespSendEvent, err error)
+	GetPresence(userID id.UserID) (resp *mautrix.RespPresence, err error)
 	ResolveAlias(alias mautrixId.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
 	SyncWithContext(ctx context.Context) error
 }
@@ -187,6 +189,15 @@ func (client *client) OnMessage(handler func(roomID room.ID, message message.Mes
 	})
 
 	return nil
+}
+
+func (client *client) GetPresence(userID string) string {
+	respPresence, err := client.mautrix.GetPresence(id.UserID(userID))
+	if err != nil {
+		fmt.Printf("error getting presence: %s", err)
+		return "unknown"
+	}
+	return string(respPresence.Presence) // this detection can be improved further if we want to take last_active_ago in account and not rely on presence status alone
 }
 
 func (client *client) JoinRoom(id room.ID) (err error) {

--- a/resources/tests/mocks/mautrix_client.go
+++ b/resources/tests/mocks/mautrix_client.go
@@ -18,6 +18,7 @@ type MautrixClientMock interface {
 	JoinRoom(roomIDorAlias string, serverName string, content interface{}) (resp *mautrix.RespJoinRoom, err error)
 	WasRoomJoined(roomIDorAlias string) bool
 	ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error)
+	GetPresence(userID id.UserID) (resp *mautrix.RespPresence, err error)
 	SyncWithContextWasCalled() bool
 	SyncWithContext(ctx context.Context) error
 }
@@ -100,6 +101,13 @@ func (m *mautrixClientMock) WasRoomJoined(roomIDorAlias string) bool {
 	}
 
 	return false
+}
+
+func (m *mautrixClientMock) GetPresence(userID id.UserID) (resp *mautrix.RespPresence, err error) {
+	if strings.Contains(string(userID), "online") {
+		return &mautrix.RespPresence{Presence: "online"}, nil
+	}
+	return &mautrix.RespPresence{Presence: "offline"}, nil
 }
 
 func (m *mautrixClientMock) ResolveAlias(alias id.RoomAlias) (resp *mautrix.RespAliasResolve, err error) {


### PR DESCRIPTION
This PR implements `GetPresence()` on `Client` interface and use that in implementing `filterOnlineUsers` workflow step